### PR TITLE
Pre post reboot control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.0
+
+Fixes pending reboot logic, adds pre/post-patching & pre-reboot command support
+
+**Features**
+- Ensures pending reboots are handled correctly, skipping patch installs completely
+- Allows defining `Exec` resources dynamically for pre/post-patching & pre-reboot commands
+- Refactors reboot logic into main manifest
+
+**Known Issues**
+Tested on Windows 2016 and 2019, and CentOS 7
+
 ## Release 0.1.0
 
 Initial release

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -34,4 +34,6 @@ patching_as_code::patch_schedule:
 
 patching_as_code::blacklist: []
 patching_as_code::whitelist: []
-
+pre_patch_commands: {}
+post_patch_commands: {}
+pre_reboot_commands: {}

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -34,6 +34,6 @@ patching_as_code::patch_schedule:
 
 patching_as_code::blacklist: []
 patching_as_code::whitelist: []
-pre_patch_commands: {}
-post_patch_commands: {}
-pre_reboot_commands: {}
+patching_as_code::pre_patch_commands: {}
+patching_as_code::post_patch_commands: {}
+patching_as_code::pre_reboot_commands: {}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,48 +98,67 @@ class patching_as_code(
     }
 
     if $available_updates.count > 0 {
-      case $facts['kernel'].downcase() {
-        /(windows|linux)/: {
-          # Run pre-patch commands if provided
-          $pre_patch_commands.each | $cmd, $cmd_opts | {
-            exec { "Patching as Code - Before patching - ${cmd}":
-              *      => $cmd_opts,
-              before => Class["patching_as_code::${0}::patchday"]
-            }
-          }
-          # Perform main patching run
-          class { "patching_as_code::${0}::patchday":
-            updates    => $updates_to_install,
-            patch_fact => $patch_fact,
-            reboot     => $reboot
-          }
-          if $reboot == true {
-            $post_patch_commands.each | $cmd, $cmd_opts | {
-              exec { "Patching as Code - After patching - ${cmd}":
-                *       => $cmd_opts,
-                require => Class["patching_as_code::${0}::patchday"],
-                before  => Reboot['Patching as Code - Patch Reboot'],
-              } -> Exec <| tag == 'patching_as_code_pre_reboot' |>
-            }
-            $pre_reboot_commands.each | $cmd, $cmd_opts | {
-              exec { "Patching as Code - Before reboot - ${cmd}":
-                *       => $cmd_opts,
-                require => Class["patching_as_code::${0}::patchday"],
-                before  => Reboot['Patching as Code - Patch Reboot'],
-                tag     => ['patching_as_code_pre_reboot']
-              }
-            }
-          } else {
-            $post_patch_commands.each | $cmd, $cmd_opts | {
-              exec { "Patching as Code - After patching - ${cmd}":
-                *       => $cmd_opts,
-                require => Class["patching_as_code::${0}::patchday"]
-              }
-            }
-          }
+      if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot == true {
+        # Pending reboot present, prevent patching and reboot immediately
+        reboot { 'Patching as Code - Patch Reboot':
+          apply    => 'immediately',
+          schedule => 'Patching as Code - Patch Window'
         }
-        default: {
-          fail('Unsupported operating system!')
+        notify { 'Patching as Code - Pending reboot detected, performing reboot before patching...':
+          schedule => 'Patching as Code - Patch Window',
+          notify   => Reboot['Patching as Code - Patch Reboot']
+        }
+      } else {
+        # No pending reboots present or reboots not allowed, proceeding
+        case $facts['kernel'].downcase() {
+          /(windows|linux)/: {
+            # Run pre-patch commands if provided
+            $pre_patch_commands.each | $cmd, $cmd_opts | {
+              exec { "Patching as Code - Before patching - ${cmd}":
+                *      => $cmd_opts,
+                before => Class["patching_as_code::${0}::patchday"]
+              }
+            }
+            # Perform main patching run
+            class { "patching_as_code::${0}::patchday":
+              updates    => $updates_to_install,
+              patch_fact => $patch_fact,
+              reboot     => $reboot
+            }
+            if $reboot == true {
+              # Reboot after patching
+              $post_patch_commands.each | $cmd, $cmd_opts | {
+                exec { "Patching as Code - After patching - ${cmd}":
+                  *       => $cmd_opts,
+                  require => Class["patching_as_code::${0}::patchday"],
+                  before  => Reboot['Patching as Code - Patch Reboot'],
+                } -> Exec <| tag == 'patching_as_code_pre_reboot' |>
+              }
+              $pre_reboot_commands.each | $cmd, $cmd_opts | {
+                exec { "Patching as Code - Before reboot - ${cmd}":
+                  *       => $cmd_opts,
+                  require => Class["patching_as_code::${0}::patchday"],
+                  before  => Reboot['Patching as Code - Patch Reboot'],
+                  tag     => ['patching_as_code_pre_reboot']
+                }
+              }
+              reboot { 'Patching as Code - Patch Reboot':
+                apply    => 'finished',
+                schedule => 'Patching as Code - Patch Window'
+              }
+            } else {
+              # Do not reboot after patching, just run post_patch commands if given
+              $post_patch_commands.each | $cmd, $cmd_opts | {
+                exec { "Patching as Code - After patching - ${cmd}":
+                  *       => $cmd_opts,
+                  require => Class["patching_as_code::${0}::patchday"]
+                }
+              }
+            }
+          }
+          default: {
+            fail('Unsupported operating system!')
+          }
         }
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,9 +6,9 @@ class patching_as_code(
   Hash              $patch_schedule,
   Array             $blacklist,
   Array             $whitelist,
-  Array             $pre_patch_commands,
-  Array             $post_patch_commands,
-  Array             $pre_reboot_commands,
+  Hash              $pre_patch_commands,
+  Hash              $post_patch_commands,
+  Hash              $pre_reboot_commands,
   Optional[Boolean] $use_pe_patch = true, # Use the pe_patch module if available (PE 2019.8+)
 ) {
   # Verify the $patch_group value points to a valid patch schedule

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,12 +93,12 @@ class patching_as_code(
     $reboot = case $_reboot {
       'always':   {true}
       'never':    {false}
-      'ifneeded': {$facts[$patch_fact]['reboots']['reboot_required']}
+      'ifneeded': {$facts[$patch_fact]['reboots']['reboot_required'] ? {true => true, default => false}}
       default:    {false}
     }
 
     if $available_updates.count > 0 {
-      if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot == true {
+      if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
         # Pending reboot present, prevent patching and reboot immediately
         reboot { 'Patching as Code - Patch Reboot':
           apply    => 'immediately',
@@ -125,7 +125,7 @@ class patching_as_code(
               patch_fact => $patch_fact,
               reboot     => $reboot
             }
-            if $reboot == true {
+            if $reboot {
               # Reboot after patching
               $post_patch_commands.each | $cmd, $cmd_opts | {
                 exec { "Patching as Code - After patching - ${cmd}":

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -4,21 +4,11 @@
 class patching_as_code::linux::patchday (
   Array $updates,
   String $patch_fact,
-  Enum['always', 'never', 'ifneeded'] $reboot
+  Boolean $reboot
 ) {
 
-  $_reboot = if $reboot == 'always' {
-              true
-            }
-            elsif $reboot == 'never' {
-              false
-            }
-            else {
-              $facts[$patch_fact]['reboots']['reboot_required']
-            }
-
   if $updates.size > 0 {
-    if $facts[$patch_fact]['reboots']['reboot_required'] == true and $_reboot {
+    if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
       Package {
         require => Reboot['Patching as Code - Patch Reboot']
       }
@@ -26,13 +16,13 @@ class patching_as_code::linux::patchday (
         schedule => 'Patching as Code - Patch Window',
         notify   => Reboot['Patching as Code - Patch Reboot']
       }
-    } elsif $_reboot {
+    } elsif $reboot {
       Package {
         notify => Reboot['Patching as Code - Patch Reboot']
       }
     }
 
-    if $_reboot {
+    if $reboot {
       reboot { 'Patching as Code - Patch Reboot':
         apply    => 'finished',
         schedule => 'Patching as Code - Patch Window'

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -4,21 +4,11 @@
 class patching_as_code::windows::patchday (
   Array $updates,
   String $patch_fact,
-  Enum['always', 'never', 'ifneeded'] $reboot
+  Boolean $reboot
 ) {
 
-  $_reboot = if $reboot == 'always' {
-              true
-            }
-            elsif $reboot == 'never' {
-              false
-            }
-            else {
-              $facts[$patch_fact]['reboots']['reboot_required']
-            }
-
   if $updates.size > 0 {
-    if $facts[$patch_fact]['reboots']['reboot_required'] == true and $_reboot {
+    if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
       Windows_updates::Kb {
         require => Reboot['Patching as Code - Patch Reboot']
       }
@@ -26,13 +16,13 @@ class patching_as_code::windows::patchday (
         schedule => 'Patching as Code - Patch Window',
         notify   => Reboot['Patching as Code - Patch Reboot']
       }
-    } elsif $_reboot {
+    } elsif $reboot {
       Windows_updates::Kb {
         notify => Reboot['Patching as Code - Patch Reboot']
       }
     }
 
-    if $_reboot {
+    if $reboot {
       reboot { 'Patching as Code - Patch Reboot':
         apply    => 'finished',
         schedule => 'Patching as Code - Patch Window'

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -7,35 +7,18 @@ class patching_as_code::windows::patchday (
   Boolean $reboot
 ) {
 
-  if $updates.size > 0 {
-    if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
-      Windows_updates::Kb {
-        require => Reboot['Patching as Code - Patch Reboot']
-      }
-      notify { 'Found pending reboot, performing reboot before patching...':
-        schedule => 'Patching as Code - Patch Window',
-        notify   => Reboot['Patching as Code - Patch Reboot']
-      }
-    } elsif $reboot {
-      Windows_updates::Kb {
-        notify => Reboot['Patching as Code - Patch Reboot']
-      }
-    }
-
+  $updates.each | $kb | {
     if $reboot {
-      reboot { 'Patching as Code - Patch Reboot':
-        apply    => 'finished',
-        schedule => 'Patching as Code - Patch Window'
-      }
-    }
-
-    $updates.each | $kb | {
       windows_updates::kb { $kb:
         ensure      => 'present',
         maintwindow => 'Patching as Code - Patch Window',
+        notify      => Reboot['Patching as Code - Patch Reboot']
+      }
+    } else {
+      windows_updates::kb { $kb:
+        ensure      => 'present',
+        maintwindow => 'Patching as Code - Patch Window'
       }
     }
-
   }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Kevin Reeuwijk",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Ensures pending reboots are handled correctly, skipping patch installs completely
- Allows defining `Exec` resources dynamically for pre/post-patching & pre-reboot commands
- Refactors reboot logic into main manifest