### PR TITLE
Add control for metered links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.3
+
+**Features**
+- Added a `metered_link` custom fact that detects metered network connections on Windows
+- Added a `patch_on_metered_links` parameter to the `patching_as_code` class, which controls if patches are installed when running over a metered link (Windows only). Defaults to `false`.
+
+## Release 0.2.2
+
+**Features**
+- This update ensures that patching_as_code defaults to NOT classify the pe_patch class on PE 2019.8.0, so that you can use the builtin "PE Patch Management" node group(s) to classify pe_patch. Since UI will be further improved in PE for this, it makes sense that this would be the leading way to classify pe_patch. This module can still be given control over pe_patch, as described in the updated Readme.
+- The blacklist and whitelist have been renamed to blocklist and allowlist.
+- Documentation has been updated, with a reference for the main manifest.
+
 ## Release 0.2.1
 
 **Bugfixes**

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -130,3 +130,14 @@ the patch_group variable in pe_patch with the patch_group in patching_as_code
 
 Default value: `false`
 
+##### `patch_on_metered_links`
+
+Data type: `Optional[Boolean]`
+
+Controls if patches are installed when the active network connection is a
+metered link. This setting only has affect for Windows operating systems.
+When enabled, patching are installed even over a metered link.
+When disabled (default), patches are not installed over a metered link.
+
+Default value: `false`
+

--- a/lib/facter/metered_link.rb
+++ b/lib/facter/metered_link.rb
@@ -1,0 +1,16 @@
+Facter.add('metered_link') do
+    confine kernel: 'windows'
+    setcode do
+      sysroot = ENV['SystemRoot']
+      powershell = "#{sysroot}\\system32\\WindowsPowerShell\\v1.0\\powershell.exe"
+      # get the script path relative to facter Ruby program
+      checker_script = File.join(
+        File.expand_path(File.dirname(__FILE__)),
+        '..',
+        'patching_as_code',
+        'metered_link.ps1',
+      )
+      Facter::Util::Resolution.exec("#{powershell} -ExecutionPolicy Unrestricted -File #{checker_script}")
+    end
+  end
+  

--- a/lib/facter/metered_link.rb
+++ b/lib/facter/metered_link.rb
@@ -1,16 +1,15 @@
 Facter.add('metered_link') do
-    confine kernel: 'windows'
-    setcode do
-      sysroot = ENV['SystemRoot']
-      powershell = "#{sysroot}\\system32\\WindowsPowerShell\\v1.0\\powershell.exe"
-      # get the script path relative to facter Ruby program
-      checker_script = File.join(
-        File.expand_path(File.dirname(__FILE__)),
-        '..',
-        'patching_as_code',
-        'metered_link.ps1',
-      )
-      Facter::Util::Resolution.exec("#{powershell} -ExecutionPolicy Unrestricted -File #{checker_script}")
-    end
+  confine kernel: 'windows'
+  setcode do
+    sysroot = ENV['SystemRoot']
+    powershell = "#{sysroot}\\system32\\WindowsPowerShell\\v1.0\\powershell.exe"
+    # get the script path relative to facter Ruby program
+    checker_script = File.join(
+      File.expand_path(File.dirname(__FILE__)),
+      '..',
+      'patching_as_code',
+      'metered_link.ps1',
+    )
+    Facter::Util::Resolution.exec("#{powershell} -ExecutionPolicy Unrestricted -File #{checker_script}")
   end
-  
+end

--- a/lib/patching_as_code/metered_link.ps1
+++ b/lib/patching_as_code/metered_link.ps1
@@ -1,0 +1,19 @@
+$defaultGateways = get-netroute -DestinationPrefix '0.0.0.0/0'
+$gwMetrics = @(foreach ($gw in $defaultGateways) {
+    New-Object -Type PSObject -Property @{
+        'ifIndex' = $gw.InterfaceIndex
+        'ifMetric' = $gw.RouteMetric + $gw.InterfaceMetric
+    }
+})
+
+$ifIndex = ($gwMetrics | ? IfMetric -eq ($gwMetrics | Measure-Object -Property ifMetric -Minimum).Minimum).IfIndex
+$if = Get-NetAdapter -InterfaceIndex $ifIndex
+
+$blnMetered = $false
+if (Test-Path "HKLM:\SOFTWARE\Microsoft\DusmSvc\Profiles\$($if.InterfaceGuid)\*") {
+    if ((Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\DusmSvc\Profiles\$($if.InterfaceGuid)\*").UserCost -eq 2) {
+        $blnMetered = $true
+    }
+}
+
+Write-Host "metered_link=$($blnMetered.ToString().ToLower())"

--- a/lib/patching_as_code/metered_link.ps1
+++ b/lib/patching_as_code/metered_link.ps1
@@ -16,4 +16,4 @@ if (Test-Path "HKLM:\SOFTWARE\Microsoft\DusmSvc\Profiles\$($if.InterfaceGuid)\*"
     }
 }
 
-Write-Host "metered_link=$($blnMetered.ToString().ToLower())"
+Write-Host $blnMetered.ToString().ToLower()

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,7 @@ class patching_as_code(
   Hash              $pre_reboot_commands,
   Optional[Boolean] $use_pe_patch = true,
   Optional[Boolean] $classify_pe_patch = false,
+  Optional[Boolean] $patch_on_metered_links = false
 ) {
   # Verify the $patch_group value points to a valid patch schedule
   unless $patch_schedule[$patch_group] or $patch_group in ['always', 'never'] {
@@ -114,7 +115,7 @@ class patching_as_code(
         range  => '00:00 - 23:59',
         repeat => 1440
       }
-      $_reboot = 'always'
+      $_reboot = 'ifneeded'
     }
     'never': {
       $bool_patch_day = false
@@ -166,71 +167,73 @@ class patching_as_code(
       default:    {false}
     }
 
-    if $available_updates.count > 0 {
-      if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
-        # Pending reboot present, prevent patching and reboot immediately
-        reboot { 'Patching as Code - Patch Reboot':
-          apply    => 'immediately',
-          schedule => 'Patching as Code - Patch Window'
-        }
-        notify { 'Patching as Code - Pending reboot detected, performing reboot before patching...':
-          schedule => 'Patching as Code - Patch Window',
-          notify   => Reboot['Patching as Code - Patch Reboot']
-        }
-      } else {
-        # No pending reboots present or reboots not allowed, proceeding
-        case $facts['kernel'].downcase() {
-          /(windows|linux)/: {
-            # Run pre-patch commands if provided
-            $pre_patch_commands.each | $cmd, $cmd_opts | {
-              exec { "Patching as Code - Before patching - ${cmd}":
-                *        => $cmd_opts,
-                before   => Class["patching_as_code::${0}::patchday"],
-                schedule => 'Patching as Code - Patch Window'
-              }
-            }
-            # Perform main patching run
-            class { "patching_as_code::${0}::patchday":
-              updates    => $updates_to_install,
-              patch_fact => $patch_fact,
-              reboot     => $reboot
-            }
-            if $reboot {
-              # Reboot after patching
-              $post_patch_commands.each | $cmd, $cmd_opts | {
-                exec { "Patching as Code - After patching - ${cmd}":
-                  *        => $cmd_opts,
-                  require  => Class["patching_as_code::${0}::patchday"],
-                  before   => Reboot['Patching as Code - Patch Reboot'],
-                  schedule => 'Patching as Code - Patch Window'
-                } -> Exec <| tag == 'patching_as_code_pre_reboot' |>
-              }
-              $pre_reboot_commands.each | $cmd, $cmd_opts | {
-                exec { "Patching as Code - Before reboot - ${cmd}":
-                  *        => $cmd_opts,
-                  require  => Class["patching_as_code::${0}::patchday"],
-                  before   => Reboot['Patching as Code - Patch Reboot'],
-                  schedule => 'Patching as Code - Patch Window',
-                  tag      => ['patching_as_code_pre_reboot']
-                }
-              }
-              reboot { 'Patching as Code - Patch Reboot':
-                apply    => 'finished',
-                schedule => 'Patching as Code - Patch Window'
-              }
-            } else {
-              # Do not reboot after patching, just run post_patch commands if given
-              $post_patch_commands.each | $cmd, $cmd_opts | {
-                exec { "Patching as Code - After patching - ${cmd}":
-                  *        => $cmd_opts,
-                  require  => Class["patching_as_code::${0}::patchday"],
-                  schedule => 'Patching as Code - Patch Window'
-                }
-              }
-            }
+    if $patch_on_metered_links or (! $facts['metered_link']) {
+      if $available_updates.count > 0 {
+        if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
+          # Pending reboot present, prevent patching and reboot immediately
+          reboot { 'Patching as Code - Patch Reboot':
+            apply    => 'immediately',
+            schedule => 'Patching as Code - Patch Window'
           }
-          default: {
-            fail('Unsupported operating system!')
+          notify { 'Patching as Code - Pending reboot detected, performing reboot before patching...':
+            schedule => 'Patching as Code - Patch Window',
+            notify   => Reboot['Patching as Code - Patch Reboot']
+          }
+        } else {
+          # No pending reboots present or reboots not allowed, proceeding
+          case $facts['kernel'].downcase() {
+            /(windows|linux)/: {
+              # Run pre-patch commands if provided
+              $pre_patch_commands.each | $cmd, $cmd_opts | {
+                exec { "Patching as Code - Before patching - ${cmd}":
+                  *        => $cmd_opts,
+                  before   => Class["patching_as_code::${0}::patchday"],
+                  schedule => 'Patching as Code - Patch Window'
+                }
+              }
+              # Perform main patching run
+              class { "patching_as_code::${0}::patchday":
+                updates    => $updates_to_install,
+                patch_fact => $patch_fact,
+                reboot     => $reboot
+              }
+              if $reboot {
+                # Reboot after patching
+                $post_patch_commands.each | $cmd, $cmd_opts | {
+                  exec { "Patching as Code - After patching - ${cmd}":
+                    *        => $cmd_opts,
+                    require  => Class["patching_as_code::${0}::patchday"],
+                    before   => Reboot['Patching as Code - Patch Reboot'],
+                    schedule => 'Patching as Code - Patch Window'
+                  } -> Exec <| tag == 'patching_as_code_pre_reboot' |>
+                }
+                $pre_reboot_commands.each | $cmd, $cmd_opts | {
+                  exec { "Patching as Code - Before reboot - ${cmd}":
+                    *        => $cmd_opts,
+                    require  => Class["patching_as_code::${0}::patchday"],
+                    before   => Reboot['Patching as Code - Patch Reboot'],
+                    schedule => 'Patching as Code - Patch Window',
+                    tag      => ['patching_as_code_pre_reboot']
+                  }
+                }
+                reboot { 'Patching as Code - Patch Reboot':
+                  apply    => 'finished',
+                  schedule => 'Patching as Code - Patch Window'
+                }
+              } else {
+                # Do not reboot after patching, just run post_patch commands if given
+                $post_patch_commands.each | $cmd, $cmd_opts | {
+                  exec { "Patching as Code - After patching - ${cmd}":
+                    *        => $cmd_opts,
+                    require  => Class["patching_as_code::${0}::patchday"],
+                    schedule => 'Patching as Code - Patch Window'
+                  }
+                }
+              }
+            }
+            default: {
+              fail('Unsupported operating system!')
+            }
           }
         }
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,11 @@
 #   When disabled (default), you can use PE's own "PE Patch Management" groups
 #   to classify nodes with pe_patch. In that case, please make sure you match
 #   the patch_group variable in pe_patch with the patch_group in patching_as_code
+# @param [Optional[Boolean]] patch_on_metered_links
+#   Controls if patches are installed when the active network connection is a
+#   metered link. This setting only has affect for Windows operating systems.
+#   When enabled, patching are installed even over a metered link.
+#   When disabled (default), patches are not installed over a metered link.
 # 
 class patching_as_code(
   String            $patch_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -167,7 +167,7 @@ class patching_as_code(
       default:    {false}
     }
 
-    if $available_updates.count > 0 {
+    if $updates_to_install.count > 0 {
       if $patch_on_metered_links or (! $facts['metered_link']) {
         if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
           # Pending reboot present, prevent patching and reboot immediately

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -167,8 +167,8 @@ class patching_as_code(
       default:    {false}
     }
 
-    if $patch_on_metered_links or (! $facts['metered_link']) {
-      if $available_updates.count > 0 {
+    if $available_updates.count > 0 {
+      if $patch_on_metered_links or (! $facts['metered_link']) {
         if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
           # Pending reboot present, prevent patching and reboot immediately
           reboot { 'Patching as Code - Patch Reboot':
@@ -236,6 +236,8 @@ class patching_as_code(
             }
           }
         }
+      } else {
+        warning('Puppet is skipping installation of patches due to the current network link being metered.')
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,7 +78,6 @@ class patching_as_code(
   Optional[Boolean] $classify_pe_patch = false,
   Optional[Boolean] $patch_on_metered_links = false
 ) {
-  notify{'TestPAC':}
   # Verify the $patch_group value points to a valid patch schedule
   unless $patch_schedule[$patch_group] or $patch_group in ['always', 'never'] {
     fail("Patch group ${patch_group} is not valid as no associated schedule was found!
@@ -238,7 +237,7 @@ class patching_as_code(
           }
         }
       } else {
-        notify{'Puppet is skipping installation of patches due to the current network link being metered.':}
+        notice('Puppet is skipping installation of patches due to the current network link being metered.')
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -237,7 +237,7 @@ class patching_as_code(
           }
         }
       } else {
-        notice("Puppet is skipping installation of patches on ${::certname} due to the current network link being metered.")
+        notice("Puppet is skipping installation of patches on ${trusted['certname']} due to the current network link being metered.")
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,7 @@ class patching_as_code(
   Optional[Boolean] $classify_pe_patch = false,
   Optional[Boolean] $patch_on_metered_links = false
 ) {
+  notify{'TestPAC':}
   # Verify the $patch_group value points to a valid patch schedule
   unless $patch_schedule[$patch_group] or $patch_group in ['always', 'never'] {
     fail("Patch group ${patch_group} is not valid as no associated schedule was found!
@@ -237,7 +238,7 @@ class patching_as_code(
           }
         }
       } else {
-        warning('Puppet is skipping installation of patches due to the current network link being metered.')
+        notify{'Puppet is skipping installation of patches due to the current network link being metered.':}
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -237,7 +237,7 @@ class patching_as_code(
           }
         }
       } else {
-        notice('Puppet is skipping installation of patches due to the current network link being metered.')
+        notice("Puppet is skipping installation of patches on ${::certname} due to the current network link being metered.")
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",
@@ -14,11 +14,11 @@
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">= 3.0.1 < 4.0.0"
+      "version_requirement": ">= 3.0.1 < 5.0.0"
     },
     {
       "name": "puppetlabs/pwshlib",
-      "version_requirement": ">= 0.4.1 < 1.0.0"
+      "version_requirement": ">= 0.4.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -59,7 +59,8 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -67,7 +68,8 @@
       "operatingsystemrelease": [
         "14.04",
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {


### PR DESCRIPTION
This PR adds control for patching over metered links. By default, when a metered link is detected (Windows only), this module will skip patching. You can control this behavior through the `patch_on_metered_links` parameter.