### PR TITLE
Version 0.2.4: fix datatype of metered_link fact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.4
+
+**Bugfixes**
+- Fixes the datatype of the `metered_link` fact, this was expected to be Boolean but got reported as a String, causing the logic to break.
+
 ## Release 0.2.3
 
 **Features**

--- a/lib/facter/metered_link.rb
+++ b/lib/facter/metered_link.rb
@@ -1,3 +1,4 @@
+
 Facter.add('metered_link') do
   confine kernel: 'windows'
   setcode do
@@ -10,6 +11,6 @@ Facter.add('metered_link') do
       'patching_as_code',
       'metered_link.ps1',
     )
-    Facter::Util::Resolution.exec("#{powershell} -ExecutionPolicy Unrestricted -File #{checker_script}")
+    Facter::Util::Resolution.exec("#{powershell} -ExecutionPolicy Unrestricted -File #{checker_script}").to_s == 'true'
   end
 end

--- a/lib/patching_as_code/metered_link.ps1
+++ b/lib/patching_as_code/metered_link.ps1
@@ -16,4 +16,4 @@ if (Test-Path "HKLM:\SOFTWARE\Microsoft\DusmSvc\Profiles\$($if.InterfaceGuid)\*"
     }
 }
 
-Write-Host $blnMetered.ToString().ToLower()
+$blnMetered | ConvertTo-Json

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,16 +173,7 @@ class patching_as_code(
     }
 
     if $updates_to_install.count > 0 {
-      notify { 'fact_value':
-         message => "The value of metered_link is: ${facts['metered_link2']}"
-      }
-      notify { 'fact_direct':
-         message => $facts['metered_link2']
-      }
-      notify { 'fact_comparison':
-         message => ! $facts['metered_link2']
-      }
-      if $patch_on_metered_links or (! $facts['metered_link']) {
+      if $patch_on_metered_links == true or ($facts['metered_link'] == false) or empty($facts['metered_link']) {
         if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
           # Pending reboot present, prevent patching and reboot immediately
           reboot { 'Patching as Code - Patch Reboot':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,7 +173,7 @@ class patching_as_code(
     }
 
     if $updates_to_install.count > 0 {
-      if $patch_on_metered_links == true or ($facts['metered_link'] == false) or empty($facts['metered_link']) {
+      if ($patch_on_metered_links == true) or (! $facts['metered_link'] == true) {
         if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
           # Pending reboot present, prevent patching and reboot immediately
           reboot { 'Patching as Code - Patch Reboot':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,13 +174,13 @@ class patching_as_code(
 
     if $updates_to_install.count > 0 {
       notify { 'fact_value':
-         message => "The value of metered_link is: ${facts['metered_link']}"
+         message => "The value of metered_link is: ${facts['metered_link2']}"
       }
       notify { 'fact_direct':
-         message => $facts['metered_link']
+         message => $facts['metered_link2']
       }
       notify { 'fact_comparison':
-         message => ! $facts['metered_link']
+         message => ! $facts['metered_link2']
       }
       if $patch_on_metered_links or (! $facts['metered_link']) {
         if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,6 +173,15 @@ class patching_as_code(
     }
 
     if $updates_to_install.count > 0 {
+      notify { 'fact_value':
+         message => "The value of metered_link is: ${facts['metered_link']}"
+      }
+      notify { 'fact_direct':
+         message => $facts['metered_link']
+      }
+      notify { 'fact_comparison':
+         message => ! $facts['metered_link']
+      }
       if $patch_on_metered_links or (! $facts['metered_link']) {
         if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
           # Pending reboot present, prevent patching and reboot immediately

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR fixes the metered_link fact to be reported as a Boolean. It was accidentally interpreted as a String, which broke the logic in the Puppet code.