### PR TITLE
v0.2.6 - skip patching if an unsafe process is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.6
+
+**Features**
+- Added a `patch_unsafe_process_active` custom fact that reflects if any process from the `unsafe_process_list` parameter was found active on the system.
+- Added a `unsafe_process_list` parameter to the `patching_as_code` class, which defines processes for the system that must cause patching to be skipped if any of those processes are active. Defaults to an empty array.
+
 ## Release 0.2.5
 
 **Features**

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [Usage](#usage)
     - [Customizing the patch groups](#customizing-the-patch-groups)
   - [Controlling which patches get installed](#controlling-which-patches-get-installed)
+  - [Defining situations when patching needs to be skipped](#Defining-situations-when-patching-needs-to-be-skipped)
   - [Defining pre/post-patching and pre-reboot commands](#defining-prepost-patching-and-pre-reboot-commands)
   - [Limitations](#limitations)
 
@@ -120,7 +121,7 @@ patching_as_code::patch_schedule:
 
 ## Controlling which patches get installed
 
-If you need to limit which patches can get installed, use the blocklist/allowlist capabilties. This is best done through Hiera.
+If you need to limit which patches can get installed, use the blocklist/allowlist capabilties. This is best done through Hiera by defining an array values for `patching_as_code::blocklist` and/or `patching_as_code::allowlist`.
 
 To prevent KB2881685 from getting installed:
 ```
@@ -135,6 +136,39 @@ patching_as_code::allowlist:
   - KB345678
 ```
 Both options can be combined, in that case the list of available updates first gets reduced to the what is allowed by the allowlist, and then gets further reduced by any blocklisted updates.
+
+## Defining situations when patching needs to be skipped
+
+There could be situations where you don't want patching to occur if certain conditions are met. This module supports two such situations:
+
+* A specific process is running that must not be interrupted by patching
+* The node to be patched is currently connected via a metered link (Windows only)
+
+### Managing unsafe processes for patching
+
+You can define a list of unsafe processes which, if any are found to be active on the node, should cause patching to be skipped. This is best done through Hiera, by defining an array value for `patching_as_code::unsafe_process_list`.
+
+To skip patching if `application1` or `application2` is among the active processes:
+```
+patching_as_code::unsafe_process_list:
+  - application1
+  - application2
+```
+
+This works on both Linux and Windows, and the matching is done case-insensitive. If one process from the unsafe_process_list is found as an active process, patching will be skipped.
+
+### Managing patching over metered links (Windows only)
+
+By default, this module will not perform patching over metered links (e.g. 3G/4G connections). You can control this behavior through the `patch_on_metered_links` parameter. To force patching to occur even over metered links, either define this value in Hiera:
+```
+patching_as_code::patch_on_metered_links: true
+```
+or set this parameter as part of calling the class:
+```
+class {'patching_as_code':
+  patch_on_metered_links => true
+}
+```
 
 ## Defining pre/post-patching and pre-reboot commands
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -73,6 +73,12 @@ Data type: `Array`
 
 List of updates that are allowed to be installed. Any updates not on this list get blocked.
 
+##### `unsafe_process_list`
+
+Data type: `Array`
+
+List of processes that will cause patching to be skipped if any of the processes in the list are active on the system.
+
 ##### `pre_patch_commands`
 
 Data type: `Hash`

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -34,6 +34,7 @@ patching_as_code::patch_schedule:
 
 patching_as_code::blocklist: []
 patching_as_code::allowlist: []
+patching_as_code::unsafe_process_list: []
 patching_as_code::pre_patch_commands: {}
 patching_as_code::post_patch_commands: {}
 patching_as_code::pre_reboot_commands: {}

--- a/lib/facter/patch_unsafe_process_active.rb
+++ b/lib/facter/patch_unsafe_process_active.rb
@@ -1,0 +1,23 @@
+require 'pathname'
+
+Facter.add('patch_unsafe_process_active') do
+  confine kernel: 'windows'
+  setcode do
+    def process_running(processname)
+      tasklist = `tasklist`.downcase
+      true if tasklist.include? processname.downcase
+    end
+    
+    processfile = Pathname.new(Puppet.settings['config'] + '/patching_unsafe_processes')
+    if processfile.exist?
+      tasklist = `tasklist`.downcase
+      unsafe_processes = File.open(processfile, 'r').read
+      unsafe_processes.each_line do |line|
+        next if line =~ /^#|^$/
+        running = process_running(line.chomp)
+        next if running == false
+        return true if running == true
+      end
+    end
+  end
+end

--- a/lib/facter/patch_unsafe_process_active.rb
+++ b/lib/facter/patch_unsafe_process_active.rb
@@ -19,6 +19,6 @@ Facter.add('patch_unsafe_process_active') do
         return true if running == true
       end      
     end
-    return false
+    false
   end
 end

--- a/lib/facter/patch_unsafe_process_active.rb
+++ b/lib/facter/patch_unsafe_process_active.rb
@@ -8,17 +8,18 @@ Facter.add('patch_unsafe_process_active') do
       true if tasklist.include? processname.downcase
     end
     
-    processfile = Pathname.new(Puppet.settings['config'] + '/patching_unsafe_processes')
+    processfile = Pathname.new(Puppet.settings['confdir'] + '/patching_unsafe_processes')
+    result = false
     if processfile.exist?
       tasklist = `tasklist`.downcase
       unsafe_processes = File.open(processfile, 'r').read
       unsafe_processes.each_line do |line|
         next if line =~ /^#|^$/
-        running = process_running(line.chomp)
-        next if running == false
-        return true if running == true
-      end      
+        next if process_running(line.chomp) == false
+        result = true
+        break
+      end
     end
-    false
+    result
   end
 end

--- a/lib/facter/patch_unsafe_process_active.rb
+++ b/lib/facter/patch_unsafe_process_active.rb
@@ -12,13 +12,13 @@ Facter.add('patch_unsafe_process_active') do
       end
       true if tasklist.include? processname.downcase
     end
-    
+
     processfile = Pathname.new(Puppet.settings['confdir'] + '/patching_unsafe_processes')
     result = false
     if processfile.exist?
       unsafe_processes = File.open(processfile, 'r').read
       unsafe_processes.each_line do |line|
-        next if line =~ /^#|^$/
+        next if line =~ %r{^#|^$}
         next if process_running(line.chomp) == false
         result = true
         break

--- a/lib/facter/patch_unsafe_process_active.rb
+++ b/lib/facter/patch_unsafe_process_active.rb
@@ -17,7 +17,8 @@ Facter.add('patch_unsafe_process_active') do
         running = process_running(line.chomp)
         next if running == false
         return true if running == true
-      end
+      end      
     end
+    return false
   end
 end

--- a/lib/facter/patch_unsafe_process_active.rb
+++ b/lib/facter/patch_unsafe_process_active.rb
@@ -10,7 +10,7 @@ Facter.add('patch_unsafe_process_active') do
       when 'Linux'
         tasklist = `ps -A`.downcase
       end
-      true if tasklist.include? processname.downcase
+      tasklist.include? processname.downcase
     end
 
     processfile = Pathname.new(Puppet.settings['confdir'] + '/patching_unsafe_processes')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,7 @@ class patching_as_code(
   Hash              $patch_schedule,
   Array             $blocklist,
   Array             $allowlist,
+  Array             $unsafe_process_list,
   Hash              $pre_patch_commands,
   Hash              $post_patch_commands,
   Hash              $pre_reboot_commands,
@@ -87,6 +88,17 @@ class patching_as_code(
   unless $patch_schedule[$patch_group] or $patch_group in ['always', 'never'] {
     fail("Patch group ${patch_group} is not valid as no associated schedule was found!
     Ensure the patching_as_code::patch_schedule parameter contains a schedule for this patch group.")
+  }
+
+  # Verify the puppet_confdir from the puppetlabs/puppet_agent module is present
+  unless $facts['puppet_confdir'] {
+    fail('The puppetlabs/patching_as_code module depends on the puppetlabs/puppet_agent module, please add it to your setup!')
+  }
+
+  # Write local config file for unsafe processes
+  file { "${facts['puppet_confdir']}/patching_unsafe_processes":
+    ensure  => file,
+    content => $unsafe_process_list.join('\n')
   }
 
   # Determine which patching module to use

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -256,12 +256,12 @@ class patching_as_code(
         }
       } else {
         if $facts['metered_link'] == true {
-          notice("Puppet is skipping installation of patches on ${trusted['certname']} due to \
-          the current network link being metered.")
+          notice("Puppet is skipping installation of patches on ${trusted['certname']} \
+          due to the current network link being metered.")
         }
         if $facts['patch_unsafe_process_active'] == true {
-          notice("Puppet is skipping installation of patches on ${trusted['certname']} because a \
-          process is active that is unsafe for patching.")
+          notice("Puppet is skipping installation of patches on ${trusted['certname']} \
+          because a process is active that is unsafe for patching.")
         }
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -185,7 +185,7 @@ class patching_as_code(
     }
 
     if $updates_to_install.count > 0 {
-      if ($patch_on_metered_links == true) or (! $facts['metered_link'] == true) {
+      if (($patch_on_metered_links == true) or (! $facts['metered_link'] == true)) and (! $facts['patch_unsafe_process_active'] == true) {
         if $facts[$patch_fact]['reboots']['reboot_required'] == true and $reboot {
           # Pending reboot present, prevent patching and reboot immediately
           reboot { 'Patching as Code - Patch Reboot':
@@ -255,7 +255,14 @@ class patching_as_code(
           }
         }
       } else {
-        notice("Puppet is skipping installation of patches on ${trusted['certname']} due to the current network link being metered.")
+        if $facts['metered_link'] == true {
+          notice("Puppet is skipping installation of patches on ${trusted['certname']} \
+          due to the current network link being metered.")
+        }
+        if $facts['patch_unsafe_process_active'] == true {
+          notice("Puppet is skipping installation of patches on ${trusted['certname']} \
+          because a process is active that is unsafe for patching.")
+        }
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,8 @@
 #   List of updates to block from installing
 # @param [Array] allowlist
 #   List of updates that are allowed to be installed. Any updates not on this list get blocked.
+# @param [Array] unsafe_process_list
+#   List of processes that will cause patching to be skipped if any of the processes in the list are active on the system.
 # @param [Hash] pre_patch_commands
 #   Hash of command to run before patching
 # @option pre_patch_commands [String] :command

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -256,12 +256,12 @@ class patching_as_code(
         }
       } else {
         if $facts['metered_link'] == true {
-          notice("Puppet is skipping installation of patches on ${trusted['certname']} \
-          due to the current network link being metered.")
+          notice("Puppet is skipping installation of patches on ${trusted['certname']} due to \
+          the current network link being metered.")
         }
         if $facts['patch_unsafe_process_active'] == true {
-          notice("Puppet is skipping installation of patches on ${trusted['certname']} \
-          because a process is active that is unsafe for patching.")
+          notice("Puppet is skipping installation of patches on ${trusted['certname']} because a \
+          process is active that is unsafe for patching.")
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Added a `patch_unsafe_process_active` custom fact that reflects if any process from the `unsafe_process_list` parameter was found active on the system.
- Added a `unsafe_process_list` parameter to the `patching_as_code` class, which defines processes for the system that must cause patching to be skipped if any of those processes are active. Defaults to an empty array.