### PR TITLE
Fix risk of duplicate declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.8
+
+**Bugfixes**
+- Ensured Linux patches cannot cause duplicate declarations
+
 ## Release 0.2.7
 
 **Bugfixes**

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -2,29 +2,23 @@
 # Performs the actual patching on Windows
 #
 class patching_as_code::windows::patchday (
-  Array $updates,
-  String $patch_fact,
+  Array   $updates,
+  String  $patch_fact,
   Boolean $reboot
 ) {
 
+  $fact_refresh = Exec["${patch_fact}::exec::fact"]
+  $patch_reboot = Reboot['Patching as Code - Patch Reboot']
+
   $updates.each | $kb | {
-    if $reboot {
-      windows_updates::kb { $kb:
-        ensure      => 'present',
-        maintwindow => 'Patching as Code - Patch Window',
-        notify      => [
-          Exec["${patch_fact}::exec::fact"],
-          Reboot['Patching as Code - Patch Reboot']
-        ]
-      }
-    } else {
-      windows_updates::kb { $kb:
-        ensure      => 'present',
-        maintwindow => 'Patching as Code - Patch Window',
-        notify      => [
-          Exec["${patch_fact}::exec::fact"],
-        ]
-      }
+    $triggers = $reboot ? {
+      true  => [ $fact_refresh, $patch_reboot ],
+      false => [ $fact_refresh ]
+    }
+    windows_updates::kb { $kb:
+      ensure      => 'present',
+      maintwindow => 'Patching as Code - Patch Window',
+      notify      => $triggers
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",
@@ -98,7 +98,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.0 < 7.0.0"
+      "version_requirement": ">= 5.5.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.18.0",


### PR DESCRIPTION
This PR changes the Linux patchday code to use a resource collector and the `ensure_packages()` function to define the patch package in a way that prevents possible duplicate resource declarations.

Fixes Issue #10