### PR TITLE
Support existing package declarations that specify a version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.9
+
+**Bugfixes**
+- Also protect against duplicate package declarations when `ensure` is set to a version. This isn't 100% bulletproof as the check is parse-order-dependent, but will work in most cases.
+
 ## Release 0.2.8
 
 **Bugfixes**

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,11 +97,6 @@ class patching_as_code(
     fail('The puppetlabs/patching_as_code module depends on the puppetlabs/puppet_agent module, please add it to your setup!')
   }
 
-  # Define patching stage, to ensure defined() lookups happen after main stage
-  stage { 'patchday':
-    require => Stage['main'],
-  }
-
   # Write local config file for unsafe processes
   file { "${facts['puppet_confdir']}/patching_unsafe_processes":
     ensure  => file,
@@ -219,8 +214,7 @@ class patching_as_code(
               class { "patching_as_code::${0}::patchday":
                 updates    => $updates_to_install,
                 patch_fact => $patch_fact,
-                reboot     => $reboot,
-                stage      => 'patchday'
+                reboot     => $reboot
               }
               if $reboot {
                 # Reboot after patching

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,6 +97,11 @@ class patching_as_code(
     fail('The puppetlabs/patching_as_code module depends on the puppetlabs/puppet_agent module, please add it to your setup!')
   }
 
+  # Define patching stage, to ensure defined() lookups happen after main stage
+  stage { 'patchday':
+    require => Stage['main'],
+  }
+
   # Write local config file for unsafe processes
   file { "${facts['puppet_confdir']}/patching_unsafe_processes":
     ensure  => file,
@@ -214,7 +219,8 @@ class patching_as_code(
               class { "patching_as_code::${0}::patchday":
                 updates    => $updates_to_install,
                 patch_fact => $patch_fact,
-                reboot     => $reboot
+                reboot     => $reboot,
+                stage      => 'patchday'
               }
               if $reboot {
                 # Reboot after patching

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -53,16 +53,14 @@ class patching_as_code::linux::patchday (
       true  => [ $fact_refresh, $patch_reboot ],
       false => [ $fact_refresh ]
     }
-    unless Package[$package] {
-      # Use a package resource to update otherwise unmanaged packages
-      package { $package:
-        ensure   => 'latest',
-        schedule => 'Patching as Code - Patch Window',
-        require  => $clean_exec,
-        notify   => $triggers
-      }
+    # Use a virtual resource to safely declare the package first.
+    @package { $package:
+      ensure   => 'latest',
     }
-    # Use a resource collector to temporarily override packages defined elsewhere
+    # Use a resource collector to safely realize the package and
+    # override its parameters. If the package is declared somewhere
+    # else as well, the collector will combine the declarations and
+    # temporarily use the parameters we set here.
     Package <| title == $package |> {
       ensure   => 'latest',
       schedule => 'Patching as Code - Patch Window',

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -53,17 +53,21 @@ class patching_as_code::linux::patchday (
       true  => [ $fact_refresh, $patch_reboot ],
       false => [ $fact_refresh ]
     }
-    # Use a virtual resource to safely declare the package first.
-    @package { "patch_update_${package}":
-      ensure   => 'latest',
-      name     => $package,
-      schedule => 'Patching as Code - Patch Window',
-      require  => $clean_exec,
-      notify   => $triggers,
-      tag      => 'patching_as_code'
+    if Package[$package] {
+      notify{"Package ${package} is defined in catalog":}
     }
+    
+    # Use a virtual resource to safely declare the package first.
+    # @package { "patch_update_${package}":
+    #   ensure   => 'latest',
+    #   name     => $package,
+    #   schedule => 'Patching as Code - Patch Window',
+    #   require  => $clean_exec,
+    #   notify   => $triggers,
+    #   tag      => 'patching_as_code'
+    # }
   }
 
   # Use a resource collector to safely realize all packages.
-  Package <| tag == 'patching_as_code' |>
+  # Package <| tag == 'patching_as_code' |>
 }

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -53,13 +53,22 @@ class patching_as_code::linux::patchday (
       true  => [ $fact_refresh, $patch_reboot ],
       false => [ $fact_refresh ]
     }
+    # Use a resource collector to temporarily override packages defined elsewhere
     Package <| title == $package |> {
       ensure   => 'latest',
       schedule => 'Patching as Code - Patch Window',
       require  => $clean_exec,
       notify   => $triggers
     }
+    unless Package[$package] {
+      # Use a package resource to update otherwise unmanaged packages
+      package { $package:
+        ensure   => 'latest',
+        schedule => 'Patching as Code - Patch Window',
+        require  => $clean_exec,
+        notify   => $triggers
+      }
+    }
   }
-  ensure_packages($updates,{'ensure' => 'latest'})
 
 }

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -53,7 +53,7 @@ class patching_as_code::linux::patchday (
       true  => [ $fact_refresh, $patch_reboot ],
       false => [ $fact_refresh ]
     }
-    if defined(Package[$package]) {
+    if defined_with_params(Package[$package]) {
       # Package resource already declared elsewhere, collect & override params for patching
       Package <| title == $package |> {
         ensure   => 'latest',

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -54,19 +54,16 @@ class patching_as_code::linux::patchday (
       false => [ $fact_refresh ]
     }
     # Use a virtual resource to safely declare the package first.
-    @package { $package:
+    @package { "patch_update_${package}":
       ensure   => 'latest',
-    }
-    # Use a resource collector to safely realize the package and
-    # override its parameters. If the package is declared somewhere
-    # else as well, the collector will combine the declarations and
-    # temporarily use the parameters we set here.
-    Package <| title == $package |> {
-      ensure   => 'latest',
+      name     => $package,
       schedule => 'Patching as Code - Patch Window',
       require  => $clean_exec,
-      notify   => $triggers
+      notify   => $triggers,
+      tag      => 'patching_as_code'
     }
   }
 
+  # Use a resource collector to safely realize all packages.
+  Package <| tag == 'patching_as_code' |>
 }

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -53,8 +53,8 @@ class patching_as_code::linux::patchday (
       true  => [ $fact_refresh, $patch_reboot ],
       false => [ $fact_refresh ]
     }
-    if Package[$package] {
-      notify{"Patching: Package ${package} is defined in catalog":}
+    if defined_with_params(Package[$package]) {
+      notify{"Patching: Package[${package}] is defined":}
     }
 
     # Use a virtual resource to safely declare the package first.

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -53,13 +53,6 @@ class patching_as_code::linux::patchday (
       true  => [ $fact_refresh, $patch_reboot ],
       false => [ $fact_refresh ]
     }
-    # Use a resource collector to temporarily override packages defined elsewhere
-    Package <| title == $package |> {
-      ensure   => 'latest',
-      schedule => 'Patching as Code - Patch Window',
-      require  => $clean_exec,
-      notify   => $triggers
-    }
     unless Package[$package] {
       # Use a package resource to update otherwise unmanaged packages
       package { $package:
@@ -68,6 +61,13 @@ class patching_as_code::linux::patchday (
         require  => $clean_exec,
         notify   => $triggers
       }
+    }
+    # Use a resource collector to temporarily override packages defined elsewhere
+    Package <| title == $package |> {
+      ensure   => 'latest',
+      schedule => 'Patching as Code - Patch Window',
+      require  => $clean_exec,
+      notify   => $triggers
     }
   }
 

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -54,9 +54,12 @@ class patching_as_code::linux::patchday (
       false => [ $fact_refresh ]
     }
     if defined_with_params(Package[$package]) {
-      notify{"Patching: Package[${package}] is defined":}
+      notify{"Patching1: Package[${package}] is defined":}
     }
 
+    if defined(Package[$package]) {
+      notify{"Patching2: Package[${package}] is defined":}
+    }
     # Use a virtual resource to safely declare the package first.
     # @package { "patch_update_${package}":
     #   ensure   => 'latest',

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -60,6 +60,6 @@ class patching_as_code::linux::patchday (
       notify   => $triggers
     }
   }
-  ensure_packages($updates)
+  ensure_packages($updates,{'ensure' => 'latest'})
 
 }

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -54,9 +54,9 @@ class patching_as_code::linux::patchday (
       false => [ $fact_refresh ]
     }
     if Package[$package] {
-      notify{"Package ${package} is defined in catalog":}
+      notify{"Patching: Package ${package} is defined in catalog":}
     }
-    
+
     # Use a virtual resource to safely declare the package first.
     # @package { "patch_update_${package}":
     #   ensure   => 'latest',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR helps further protect against duplicate package declarations when `ensure` is set to a version. This isn't 100% bulletproof as the check is parse-order-dependent, but will work in most cases.