### PR TITLE
v0.6.0 - patch_group and scheduling improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.6.0
+
+**Features**
+- Adds support for providing an array of values to the `patch_group` attribute of the `patching_as_code` class
+- Adds support for providing an array of values to the `count_of_week` parameter in a patch schedule
+
 ## Release 0.5.0
 
 **Features**

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ or, in flow style:
 patching_as_code::patch_group: [ testing, early ]
 ```
 
+Note: if you assign a node to multiple patch groups, the value for the patch group provided to `pe_patch`/`os_patching` will be a space-separated list of the assigned patch groups. This is because `pe_patch`/`os_patching` do not natively support multiple patch groups, so we work around this by converting our list a single string that `pe_patch`/`os_patching` can work with. This is purely for cosmetic purposes and does not affect the functionality of either solution.
+
 ### Customizing the patch groups
 
 You can customize the patch groups to whatever you need. To do so, simply copy the `patching_as_code::patch_schedule` hash from the `data/common.yaml` in this module, and paste it into your own Hiera store (recommended to place it in your Hiera's own `common.yaml`). This Hiera value will now override the defaults that the module provides. Customize the hash to your needs.

--- a/README.md
+++ b/README.md
@@ -65,13 +65,14 @@ This will change the behavior to also declare the `pe_patch` class, and match it
 
 ## Usage
 
-To control which patch group a node belongs to, you need to set the `patch_group` parameter of the class.
+To control which patch group(s) a node belongs to, you need to set the `patch_group` parameter of the class.
 It is highly recommended to use Hiera to set the correct value for each node, for example:
 ```
 patching_as_code::patch_group: early
 ```
-The module provides 5 patch groups out of the box:
+The module provides 6 patch groups out of the box:
 ```
+weekly:    patches each Thursday of the month, between 09:00 and 11:00, performs a reboot if needed
 testing:   patches every 2nd Thursday of the month, between 07:00 and 09:00, performs a reboot if needed
 early:     patches every 3rd Monday   of the month, between 20:00 and 22:00, performs a reboot if needed
 primary:   patches every 3rd Friday   of the month, between 22:00 and 00:00, performs a reboot if needed
@@ -82,6 +83,17 @@ There are also 2 special built-in patch groups:
 ```
 always:    patches immediately when a patch is available, can patch in any agent run, performs a reboot if needed
 never:     never performs any patching and does not reboot
+```
+
+If you want to assign a node to multiple patch groups, specify an array of values in Hiera:
+```
+patching_as_code::patch_group:
+  - testing
+  - early
+```
+or, in flow style:
+```
+patching_as_code::patch_group: [ testing, early ]
 ```
 
 ### Customizing the patch groups
@@ -101,7 +113,7 @@ patching_as_code::patch_schedule:
 For example, say you want to have the following 2 patch groups:
 ```
 group1: patches every 2nd Sunday of the month, between 10:00 and 11:00, max 1 time, reboots if needed
-group2: patches every 3nd Monday of the month, between 20:00 and 22:00, max 3 times, does not reboot
+group2: patches every 3nd and 4th Monday of the month, between 20:00 and 22:00, max 3 times, does not reboot
 ```
 then define the hash as follows:
 ```
@@ -114,7 +126,7 @@ patching_as_code::patch_schedule:
     reboot: ifneeded
   group2:
     day_of_week: Monday
-    count_of_week: 3
+    count_of_week: [3,4]
     hours: 20:00 - 22:00
     max_runs: 3
     reboot: never

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -43,9 +43,10 @@ The following parameters are available in the `patching_as_code` class.
 
 ##### `patch_group`
 
-Data type: `String`
+Data type: `Variant[String,Array[String]]`
 
-Name of the patch_group for this node. Must match one of the patch groups in $patch_schedule
+Name(s) of the patch_group(s) for this node. Must match one or more of the patch groups in $patch_schedule
+To assign multiple patch groups, provide this parameter as an array
 
 ##### `patch_schedule`
 
@@ -56,7 +57,7 @@ Hash of available patch_schedules. Default schedules are in /data/common.yaml of
 Options:
 
 * **:day_of_week** `String`: Day of the week to patch, valid options: 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'
-* **:count_of_week** `Integer`: Which week in the month to patch, use a number between 1 and 4
+* **:count_of_week** `Variant[Integer,Array[Integer]]`: Which week(s) in the month to patch, use number(s) between 1 and 5
 * **:hours** `String`: Which hours on patch day to patch, define a range as 'HH:MM - HH:MM'
 * **:max_runs** `String`: How many Puppet runs during the patch window can Puppet install patches. Must be at least 1.
 * **:reboot** `String`: Reboot behavior, valid options: 'always', 'never', 'ifneeded'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,12 +3,7 @@ patching_as_code::patch_group: primary
 patching_as_code::patch_schedule:
   weekly:
     day_of_week: Thursday
-    count_of_week:
-      - 1
-      - 2
-      - 3
-      - 4
-      - 5
+    count_of_week: [1,2,3,4,5]
     hours: 09:00 - 11:00
     max_runs: 4
     reboot: ifneeded

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,17 @@
 ---
 patching_as_code::patch_group: primary
 patching_as_code::patch_schedule:
+  weekly:
+    day_of_week: Thursday
+    count_of_week:
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+    hours: 09:00 - 11:00
+    max_runs: 4
+    reboot: ifneeded
   testing:
     day_of_week: Thursday
     count_of_week: 2

--- a/functions/is_patchday.pp
+++ b/functions/is_patchday.pp
@@ -1,6 +1,6 @@
 function patching_as_code::is_patchday(
   Enum['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'] $day_of_week,
-  Integer $week_iteration
+  Variant[Integer, Array] $week_iteration
 ){
   $day_number = $day_of_week ? {
     'Monday'    => 1,
@@ -25,11 +25,21 @@ function patching_as_code::is_patchday(
     $firstocc = 1 + $day_number - $som_weekday
   }
 
-  # Calculate date of patch day
-  $patchday = $firstocc + (( $week_iteration - 1 ) * 7 )
+  # Calculate dates of valid patch days
+  case type($week_iteration, 'generalized') {
+    Type[Integer]: {
+      $patchdays = Array($firstocc + (( $week_iteration - 1 ) * 7 ), true)
+    }
+    Type[Array[Integer]]: {
+      $patchdays = $week_iteration.map |$week| { $firstocc + (( $week - 1 ) * 7 ) }
+    }
+    default: {
+      fail('The count_of_week parameter of the patch_schedule must be configured as an integer or an array of integers!')
+    }
+  }
 
-  # Return true if today is patch day
-  if $patchday == $dayofmonth {
+  # Return true if today is a patch day
+  if $dayofmonth in $patchdays {
     true
   } else {
     false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,13 +16,13 @@
 # 
 # @param Variant[String,Array[String]] patch_group
 #   Name(s) of the patch_group(s) for this node. Must match one or more of the patch groups in $patch_schedule
-#   To set multiple patch groups, provide this parameter as an array
+#   To assign multiple patch groups, provide this parameter as an array
 # @param [Hash] patch_schedule
 #   Hash of available patch_schedules. Default schedules are in /data/common.yaml of this module
 # @option patch_schedule [String] :day_of_week
 #   Day of the week to patch, valid options: 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'
-# @option patch_schedule [Integer] :count_of_week
-#   Which week in the month to patch, use a number between 1 and 4
+# @option patch_schedule [Variant[Integer,Array[Integer]]] :count_of_week
+#   Which week(s) in the month to patch, use number(s) between 1 and 5
 # @option patch_schedule [String] :hours
 #   Which hours on patch day to patch, define a range as 'HH:MM - HH:MM'
 # @option patch_schedule [String] :max_runs

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Adds support for providing an array of values to the `patch_group` attribute of the `patching_as_code` class
- Adds support for providing an array of values to the `count_of_week` parameter in a patch schedule