### PR TITLE
v0.6.1 - Fix wide timezone difference case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## Release 0.6.1
+
+**Bugfixes**
+- Removed the `weekday` attribute of the `schedule` resource that this module uses internally to restrict when patches can be applied. In certain edge cases where the Puppet server is in a very different timezone from a managed node, there can be a 1 day date difference between the two systems. This creates a scenario where the node never receives a valid patch schedule. By removing the `weekday` parameter from the `schedule` resource, this can no longer occur. Other logic still protects the actual day on which the patching is allowed so this parameter wasn't necessary.
+
 ## Release 0.6.0
 
 **Features**

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -196,9 +196,8 @@ class patching_as_code(
     }
     if $bool_patch_day {
       schedule { 'Patching as Code - Patch Window':
-        range   => $patch_schedule[$active_pg]['hours'],
-        weekday => $patch_schedule[$active_pg]['day_of_week'],
-        repeat  => $patch_schedule[$active_pg]['max_runs']
+        range  => $patch_schedule[$active_pg]['hours'],
+        repeat => $patch_schedule[$active_pg]['max_runs']
       }
       $_reboot = $patch_schedule[$active_pg]['reboot']
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
Removed the `weekday` attribute of the `schedule` resource that this module uses internally to restrict when patches can be applied. In certain edge cases where the Puppet server is in a very different timezone from a managed node, there can be a 1 day date difference between the two systems. This creates a scenario where the node never receives a valid patch schedule. By removing the `weekday` parameter from the `schedule` resource, this can no longer occur. Other logic still protects the actual day on which the patching is allowed so this parameter wasn't necessary.