### PR TITLE
Update boundaries for powershell

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">= 3.0.1 < 5.0.0"
+      "version_requirement": ">= 3.0.1 < 6.0.0"
     },
     {
       "name": "puppetlabs/pwshlib",


### PR DESCRIPTION
Updated puppetlabs/powershell boundary. The new version of the PowerShell module only drops Puppet 5 support, which this module doesn't have anyway.