### PR TITLE
Move post-patch reboot logic to its own stage that runs after [main]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.7.0
+
+**Features**
+- Moves the post-patch reboot logic to its own stage (`patch_reboot`), which runs after the `main` stage. This should ensure that reboots only happen at the end of the Puppet run.
+- Removed the `notify` logic for triggering the reboots from installed patches, in favor of handling the reboot logic in the new `patch_reboot` stage.
+- Deduplicated the calling of the Exec resource that refreshes the patch fact, ensuring this only happens once now.
+
 ## Release 0.6.2
 
 **Features**

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -36,7 +36,8 @@ class patching_as_code::linux::patchday (
   } -> anchor {'patching_as_code::patchday::start':
   } -> anchor {'patching_as_code::patchday::end':
   } -> notify {'Patching as Code - Update Fact':
-    notify => Exec["${patch_fact}::exec::fact"]
+    message => "Patches installed, refreshing ${patch_fact} fact...",
+    notify  => Exec["${patch_fact}::exec::fact"]
   }
 
   $updates.each | $package | {

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -35,6 +35,7 @@ class patching_as_code::linux::patchday (
     schedule => 'Patching as Code - Patch Window'
   } -> anchor {'patching_as_code::patchday::start':
   } -> anchor {'patching_as_code::patchday::end':
+  } -> notify {'Patching as Code - Update Fact':
     notify => Exec["${patch_fact}::exec::fact"]
   }
 

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -4,8 +4,6 @@
 class patching_as_code::linux::patchday (
   Array   $updates,
   String  $patch_fact,
-  Boolean $reboot,
-  Boolean $reboot_if_needed
 ) {
 
   case $facts['package_provider'] {
@@ -38,20 +36,10 @@ class patching_as_code::linux::patchday (
   } -> anchor {'patching_as_code::patchday::start':
   } -> anchor {'patching_as_code::patchday::end':}
 
-  $fact_refresh = Exec["${patch_fact}::exec::fact"]
-  $patch_reboot = $reboot_if_needed ? {
-    true  => Exec['Patching as Code - Patch Reboot'],
-    false => Reboot['Patching as Code - Patch Reboot']
-  }
-
   $updates.each | $package | {
-    $triggers = $reboot ? {
-      true  => [ $fact_refresh, $patch_reboot ],
-      false => [ $fact_refresh ]
-    }
     patch_package { $package:
       patch_window => 'Patching as Code - Patch Window',
-      triggers     => $triggers
+      triggers     => [ Exec["${patch_fact}::exec::fact"] ]
     }
   }
 }

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -34,12 +34,14 @@ class patching_as_code::linux::patchday (
     path     => $cmd_path,
     schedule => 'Patching as Code - Patch Window'
   } -> anchor {'patching_as_code::patchday::start':
-  } -> anchor {'patching_as_code::patchday::end':}
+  } -> anchor {'patching_as_code::patchday::end':
+    notify => Exec["${patch_fact}::exec::fact"]
+  }
 
   $updates.each | $package | {
     patch_package { $package:
       patch_window => 'Patching as Code - Patch Window',
-      triggers     => [ Exec["${patch_fact}::exec::fact"] ]
+      triggers     => []
     }
   }
 }

--- a/manifests/reboot.pp
+++ b/manifests/reboot.pp
@@ -1,0 +1,25 @@
+# Class: patching_as_code::reboot
+#
+#
+class patching_as_code::reboot(
+  Boolean $reboot_if_needed = true,
+  Integer $reboot_delay = 120
+) {
+  $reboot_when = $reboot_if_needed ? {
+    true  => pending,
+    false => refreshed
+  }
+
+  reboot { 'Patching as Code - Patch Reboot':
+    apply    => 'immediately',
+    schedule => 'Patching as Code - Patch Window',
+    timeout  => $reboot_delay,
+    when     => $reboot_when
+  }
+
+  unless $reboot_if_needed {
+    notify {'Patching as Code - Performing OS reboot':
+      notify => Reboot['Patching as Code - Patch Reboot']
+    }
+  }
+}

--- a/manifests/reboot.pp
+++ b/manifests/reboot.pp
@@ -5,21 +5,41 @@ class patching_as_code::reboot(
   Boolean $reboot_if_needed = true,
   Integer $reboot_delay = 120
 ) {
-  $reboot_when = $reboot_if_needed ? {
-    true  => pending,
-    false => refreshed
-  }
-
-  reboot { 'Patching as Code - Patch Reboot':
-    apply    => 'immediately',
-    schedule => 'Patching as Code - Patch Window',
-    timeout  => $reboot_delay,
-    when     => $reboot_when
-  }
-
-  unless $reboot_if_needed {
-    notify {'Patching as Code - Performing OS reboot':
-      notify => Reboot['Patching as Code - Patch Reboot']
+  $reboot_delay_min = round($reboot_delay / 60)
+  if $reboot_if_needed {
+    # Define an Exec to perform the reboot shortly after the Puppet run completes
+    case $facts['kernel'].downcase() {
+      'windows': {
+        $reboot_logic_provider = 'powershell'
+        $reboot_logic_cmd      = "& shutdown /r /t ${reboot_delay} /c \"Patching_as_code: Rebooting system due to a pending reboot after patching\" /d p:2:17" # lint:ignore:140chars 
+        $reboot_logic_onlyif   = "${facts['puppet_vardir']}/lib/patching_as_code/pending_reboot.ps1 | findstr -i True"
+      }
+      'linux': {
+        $reboot_logic_provider = 'posix'
+        $reboot_logic_cmd      = "/sbin/shutdown -r +${reboot_delay_min}"
+        $reboot_logic_onlyif   = "/bin/sh ${facts['puppet_vardir']}/lib/patching_as_code/pending_reboot.sh | grep true"
+      }
+      default: {
+        fail('Unsupported operating system for Patching as Code!')
+      }
+    }
+    exec {'Patching as Code - Patch Reboot':
+      command   => $reboot_logic_cmd,
+      onlyif    => $reboot_logic_onlyif,
+      provider  => $reboot_logic_provider,
+      logoutput => true,
+      schedule  => 'Patching as Code - Patch Window',
+    }
+  } else {
+    # Reboot as part of this Puppet run
+    reboot { 'Patching as Code - Patch Reboot':
+      apply    => 'immediately',
+      schedule => 'Patching as Code - Patch Window',
+      timeout  => $reboot_delay,
+    }
+    notify { 'Patching as Code - Performing OS reboot':
+      notify   => Reboot['Patching as Code - Patch Reboot'],
+      schedule => 'Patching as Code - Patch Window',
     }
   }
 }

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -4,25 +4,13 @@
 class patching_as_code::windows::patchday (
   Array   $updates,
   String  $patch_fact,
-  Boolean $reboot,
-  Boolean $reboot_if_needed
 ) {
 
-  $fact_refresh = Exec["${patch_fact}::exec::fact"]
-  $patch_reboot = $reboot_if_needed ? {
-    true  => Exec['Patching as Code - Patch Reboot'],
-    false => Reboot['Patching as Code - Patch Reboot']
-  }
-
   $updates.each | $kb | {
-    $triggers = $reboot ? {
-      true  => [ $fact_refresh, $patch_reboot ],
-      false => [ $fact_refresh ]
-    }
     patching_as_code::kb { $kb:
       ensure      => 'present',
       maintwindow => 'Patching as Code - Patch Window',
-      notify      => $triggers
+      notify      => [ Exec["${patch_fact}::exec::fact"] ]
     }
   }
 }

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -9,7 +9,8 @@ class patching_as_code::windows::patchday (
   anchor {'patching_as_code::patchday::start':
   } -> anchor {'patching_as_code::patchday::end':
   } -> notify {'Patching as Code - Update Fact':
-    notify => Exec["${patch_fact}::exec::fact"]
+    message => "Patches installed, refreshing ${patch_fact} fact...",
+    notify  => Exec["${patch_fact}::exec::fact"]
   }
 
   $updates.each | $kb | {

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -8,6 +8,7 @@ class patching_as_code::windows::patchday (
 
   anchor {'patching_as_code::patchday::start':
   } -> anchor {'patching_as_code::patchday::end':
+  } -> notify {'Patching as Code - Update Fact':
     notify => Exec["${patch_fact}::exec::fact"]
   }
 

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -6,11 +6,17 @@ class patching_as_code::windows::patchday (
   String  $patch_fact,
 ) {
 
+  anchor {'patching_as_code::patchday::start':
+  } -> anchor {'patching_as_code::patchday::end':
+    notify => Exec["${patch_fact}::exec::fact"]
+  }
+
   $updates.each | $kb | {
     patching_as_code::kb { $kb:
       ensure      => 'present',
       maintwindow => 'Patching as Code - Patch Window',
-      notify      => [ Exec["${patch_fact}::exec::fact"] ]
+      before      => Anchor['patching_as_code::patchday::end'],
+      require     => Anchor['patching_as_code::patchday::start'],
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Moves the post-patch reboot logic to its own stage (`patch_reboot`), which runs after the `main` stage. This should ensure that reboots only happen at the end of the Puppet run.
- Removed the `notify` logic for triggering the reboots from installed patches, in favor of handling the reboot logic in the new `patch_reboot` stage.
- Deduplicated the calling of the Exec resource that refreshes the patch fact, ensuring this only happens once now.