### PR TITLE
v0.7.1 - code improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.7.1
+
+**Improvements**
+- Adopted the `eval_generate` function in the `patch_package` type to ensure that newly generated `package` resources become children of the `patching_as_code::linux::patchday` class. This provides better context for these package resources, which can be leveraged in external reporting tools (e.g. Splunk).
+- Simplified the `patch_package` type, removed capabilities that are no longer needed
+- Moved the logic to trigger the patch fact refresh to the main manifest
+- Simplified the patchday classes
+
 ## Release 0.7.0
 
 **Features**

--- a/lib/puppet/type/patch_package.rb
+++ b/lib/puppet/type/patch_package.rb
@@ -31,7 +31,8 @@ Puppet::Type.newtype(:patch_package) do
     else
       [Puppet::Type.type(:package).new(name: name,
                                        ensure: 'latest',
-                                       schedule: self[:patch_window])]
+                                       schedule: self[:patch_window],
+                                       before: 'Anchor[patching_as_code::patchday::end]')]
     end
   end
 
@@ -51,6 +52,7 @@ Puppet::Type.newtype(:patch_package) do
         Puppet.send('notice', "#{package_res} (managed) will be updated by Patching_as_code")
         catalog.resource(package_res)['ensure'] = 'latest'
         catalog.resource(package_res)['schedule'] = self[:patch_window]
+        catalog.resource(package_res)['before'] = Array(res['before']) + ['Anchor[patching_as_code::patchday::end]']
       else
         Puppet.send('notice', "#{package_res} (managed) will not be updated by Patching_as_code, due to the package enforcing a specific version")
       end

--- a/lib/puppet/type/patch_package.rb
+++ b/lib/puppet/type/patch_package.rb
@@ -29,9 +29,7 @@ Puppet::Type.newtype(:patch_package) do
     return if package_in_catalog
     [Puppet::Type.type(:package).new(name: name,
                                     ensure: 'latest',
-                                    schedule: self[:patch_window],
-                                    before: 'Anchor[patching_as_code::patchday::end]',
-                                    require: 'Anchor[patching_as_code::patchday::start]')]
+                                    schedule: self[:patch_window])]
   end
 
   # See if the package to patch exists in the catalog
@@ -50,8 +48,6 @@ Puppet::Type.newtype(:patch_package) do
         Puppet.send('notice', "#{package_res} (managed) will be updated by Patching_as_code")
         catalog.resource(package_res)['ensure'] = 'latest'
         catalog.resource(package_res)['schedule'] = self[:patch_window]
-        catalog.resource(package_res)['before'] = Array(catalog.resource(package_res)['before']) + ['Anchor[patching_as_code::patchday::end]']
-        catalog.resource(package_res)['require'] = Array(catalog.resource(package_res)['require']) + ['Anchor[patching_as_code::patchday::start]']
       else
         Puppet.send('notice', "#{package_res} (managed) will not be updated by Patching_as_code, due to the package enforcing a specific version")
       end

--- a/lib/puppet/type/patch_package.rb
+++ b/lib/puppet/type/patch_package.rb
@@ -10,36 +10,34 @@ Puppet::Type.newtype(:patch_package) do
     desc 'Puppet schedule to link package resource to'
   end
 
-  newparam(:triggers, array_matching: :all) do
-    desc 'Resources to notify after updating the package'
-
-    munge do |values|
-      values = [values] unless values.is_a? Array
-      values
-    end
-  end
-
   # All parameters are required
   validate do
-    [:name, :patch_window, :triggers].each do |param|
+    [:name, :patch_window].each do |param|
       raise Puppet::Error, "Required parameter missing: #{param}" unless @parameters[param]
     end
   end
 
   # See if the package to patch exists in the catalog
-  # If package is found, update resource one-time for patching
   # If package is not found, create a one-time package resource
-  def pre_run_check
-    # Validate :triggers
-    triggers = parameter(:triggers)
-    triggers.value.each do |res|
-      retrieve_resource_reference(res)
-    rescue ArgumentError => e
-      raise Puppet::Error, "Parameter triggers failed: #{e} at #{@file}:#{@line}"
+  def eval_generate
+    begin
+      retrieve_resource_reference("Package[#{name}]")
+      package_in_catalog = true
+    rescue ArgumentError
+      package_in_catalog = false
     end
+    return if package_in_catalog
+    [Puppet::Type.type(:package).new(name: name,
+                                    ensure: 'latest',
+                                    schedule: self[:patch_window],
+                                    before: 'Anchor[patching_as_code::patchday::end]',
+                                    require: 'Anchor[patching_as_code::patchday::start]')]
+  end
 
-    package = self[:name]
-    package_res = "Package[#{package}]"
+  # See if the package to patch exists in the catalog
+  # If package is found, update resource one-time for patching
+  def pre_run_check
+    package_res = "Package[#{self[:name]}]"
     begin
       res = retrieve_resource_reference(package_res)
       package_in_catalog = true
@@ -54,19 +52,11 @@ Puppet::Type.newtype(:patch_package) do
         catalog.resource(package_res)['schedule'] = self[:patch_window]
         catalog.resource(package_res)['before'] = Array(catalog.resource(package_res)['before']) + ['Anchor[patching_as_code::patchday::end]']
         catalog.resource(package_res)['require'] = Array(catalog.resource(package_res)['require']) + ['Anchor[patching_as_code::patchday::start]']
-        catalog.resource(package_res)['notify'] = Array(catalog.resource(package_res)['notify']) + triggers.value
       else
         Puppet.send('notice', "#{package_res} (managed) will not be updated by Patching_as_code, due to the package enforcing a specific version")
       end
     else
       Puppet.send('notice', "#{package_res} (unmanaged) will be updated by Patching_as_code")
-      catalog.create_resource('package',
-                              title: package,
-                              ensure: 'latest',
-                              schedule: self[:patch_window],
-                              before: 'Anchor[patching_as_code::patchday::end]',
-                              require: 'Anchor[patching_as_code::patchday::start]',
-                              notify: triggers.value)
     end
   end
 

--- a/lib/puppet/type/patch_package.rb
+++ b/lib/puppet/type/patch_package.rb
@@ -26,16 +26,19 @@ Puppet::Type.newtype(:patch_package) do
     rescue ArgumentError
       package_in_catalog = false
     end
-    return if package_in_catalog
-    [Puppet::Type.type(:package).new(name: name,
-                                    ensure: 'latest',
-                                    schedule: self[:patch_window])]
+    if package_in_catalog
+      []
+    else
+      [Puppet::Type.type(:package).new(name: name,
+                                       ensure: 'latest',
+                                       schedule: self[:patch_window])]
+    end
   end
 
   # See if the package to patch exists in the catalog
   # If package is found, update resource one-time for patching
   def pre_run_check
-    package_res = "Package[#{self[:name]}]"
+    package_res = "Package[#{name}]"
     begin
       res = retrieve_resource_reference(package_res)
       package_in_catalog = true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -296,6 +296,9 @@ class patching_as_code(
             class { "patching_as_code::${0}::patchday":
               updates    => $updates_to_install,
               patch_fact => $patch_fact,
+            } -> notify {'Patching as Code - Update Fact':
+              message => "Patches installed, refreshing ${patch_fact} fact...",
+              notify  => Exec["${patch_fact}::exec::fact"]
             }
             if $reboot {
               # Reboot the node first if a reboot is already pending

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -41,4 +41,6 @@ class patching_as_code::linux::patchday (
       require      => Exec['Patching as Code - Clean Cache']
     }
   }
+
+  anchor {'patching_as_code::patchday::end':}
 }

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -42,8 +42,7 @@ class patching_as_code::linux::patchday (
 
   $updates.each | $package | {
     patch_package { $package:
-      patch_window => 'Patching as Code - Patch Window',
-      triggers     => []
+      patch_window => 'Patching as Code - Patch Window'
     }
   }
 }

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -33,16 +33,12 @@ class patching_as_code::linux::patchday (
     command  => $cmd,
     path     => $cmd_path,
     schedule => 'Patching as Code - Patch Window'
-  } -> anchor {'patching_as_code::patchday::start':
-  } -> anchor {'patching_as_code::patchday::end':
-  } -> notify {'Patching as Code - Update Fact':
-    message => "Patches installed, refreshing ${patch_fact} fact...",
-    notify  => Exec["${patch_fact}::exec::fact"]
   }
 
   $updates.each | $package | {
     patch_package { $package:
-      patch_window => 'Patching as Code - Patch Window'
+      patch_window => 'Patching as Code - Patch Window',
+      require      => Exec['Patching as Code - Clean Cache']
     }
   }
 }

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -12,4 +12,6 @@ class patching_as_code::windows::patchday (
       maintwindow => 'Patching as Code - Patch Window'
     }
   }
+
+  anchor {'patching_as_code::patchday::end':}
 }

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -6,19 +6,10 @@ class patching_as_code::windows::patchday (
   String  $patch_fact,
 ) {
 
-  anchor {'patching_as_code::patchday::start':
-  } -> anchor {'patching_as_code::patchday::end':
-  } -> notify {'Patching as Code - Update Fact':
-    message => "Patches installed, refreshing ${patch_fact} fact...",
-    notify  => Exec["${patch_fact}::exec::fact"]
-  }
-
   $updates.each | $kb | {
     patching_as_code::kb { $kb:
       ensure      => 'present',
-      maintwindow => 'Patching as Code - Patch Window',
-      before      => Anchor['patching_as_code::patchday::end'],
-      require     => Anchor['patching_as_code::patchday::start'],
+      maintwindow => 'Patching as Code - Patch Window'
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Improvements**
- Adopted the `eval_generate` function in the `patch_package` type to ensure that newly generated `package` resources become children of the `patching_as_code::linux::patchday` class. This provides better context for these package resources, which can be leveraged in external reporting tools (e.g. Splunk).
- Simplified the `patch_package` type, removed capabilities that are no longer needed
- Moved the logic to trigger the patch fact refresh to the main manifest
- Simplified the patchday classes