### PR TITLE
v0.7.4: schedule fix in Notify resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.7.4
+
+**Bugfixes**
+- Fixes a missing `schedule` metaparameter for the `Notify[Patching as Code - Update Fact]`, which would cause the `pe_patch` fact to update at every Puppet run during the patch day, instead of only during the maintenance window.
+
 ## Release 0.7.3
 
 **Bugfixes**

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -313,8 +313,9 @@ class patching_as_code(
               patch_fact => $patch_fact,
               require    => Anchor['patching_as_code::start']
             } -> notify {'Patching as Code - Update Fact':
-              message => "Patches installed, refreshing ${patch_fact} fact...",
-              notify  => Exec["${patch_fact}::exec::fact"]
+              message  => "Patches installed, refreshing ${patch_fact} fact...",
+              notify   => Exec["${patch_fact}::exec::fact"],
+              schedule => 'Patching as Code - Patch Window',
             }
             if $reboot {
               # Reboot after patching (in later patch_reboot stage)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Bugfixes**
- Fixes a missing `schedule` metaparameter for the `Notify[Patching as Code - Update Fact]`, which would cause the `pe_patch` fact to update at every Puppet run during the patch day, instead of only during the maintenance window.