### PR TITLE
v0.7.11: Fix issues caused by duplicate items in list of patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.7.11
+
+**Improvements**
+- Deduplicates the list of patches to install, preventing any possible duplicate resource declarations if the list of patches to install contains the same patch more than once for any reason
+
 ## Release 0.7.10
 
 **Improvements**

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -310,7 +310,7 @@ class patching_as_code(
             }
             # Perform main patching run
             class { "patching_as_code::${0}::patchday":
-              updates    => $updates_to_install,
+              updates    => $updates_to_install.unique,
               patch_fact => $patch_fact,
               require    => Anchor['patching_as_code::start']
             } -> notify {'Patching as Code - Update Fact':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR deduplicates the array of patches before passing it to the patchday manifest, preventing possible duplicate resource declaration errors. This fixes issue #39.