### PR TITLE
backward-compatible disabling of os_patching's fact_upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ patching_as_code::patch_group: [ testing, early ]
 
 Note: if you assign a node to multiple patch groups, the value for the patch group provided to `pe_patch`/`os_patching` will be a space-separated list of the assigned patch groups. This is because `pe_patch`/`os_patching` do not natively support multiple patch groups, so we work around this by converting our list a single string that `pe_patch`/`os_patching` can work with. This is purely for cosmetic purposes and does not affect the functionality of either solution.
 
+When using local apply for iterative development, `os_patching`'s default `fact_upload => true` may be problematic. If so, `patching_as_code`'s optional `fact_upload => false` parameter resolves. 
+
 ### Customizing the patch groups
 
 You can customize the patch groups to whatever you need. To do so, simply copy the `patching_as_code::patch_schedule` hash from the `data/common.yaml` in this module, and paste it into your own Hiera store (recommended to place it in your Hiera's own `common.yaml`). This Hiera value will now override the defaults that the module provides. Customize the hash to your needs.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,10 @@
 #   (optional) The path for the command
 # @option pre_reboot_commands [String] :provider
 #   (optional) The provider for the command
+# @param [Optional[Boolean]] fact_upload
+#   How os_patching class handles changes to fact cache. Defaults to true.
+#   When true (default), `puppet fact upload` occurs as expected
+#   When false, changes to fact cache are not uploaded
 # @param [Optional[Boolean]] use_pe_patch
 #   Use the pe_patch module if available (PE 2019.8+). Defaults to true.
 # @param [Optional[Boolean]] classify_pe_patch
@@ -83,6 +87,7 @@ class patching_as_code(
   Hash                          $pre_patch_commands,
   Hash                          $post_patch_commands,
   Hash                          $pre_reboot_commands,
+  Optional[Boolean]             $fact_upload = true,
   Optional[String]              $plan_patch_fact = undef,
   Optional[Boolean]             $enable_patching = true,
   Optional[Boolean]             $security_only = false,
@@ -140,6 +145,7 @@ class patching_as_code(
         $patch_fact = 'os_patching'
         class { 'os_patching':
           patch_window => join($patch_groups, ' '),
+          fact_upload  => $fact_upload,
         }
       }
     }
@@ -155,6 +161,7 @@ class patching_as_code(
       $patch_fact = 'os_patching'
       class { 'os_patching':
         patch_window => join($patch_groups, ' '),
+        fact_upload  => $fact_upload,
       }
     }
     default: { fail('Unsupported value for plan_patch_fact parameter!') }


### PR DESCRIPTION
Ran into an issue where customer's use case failed sending facts, os_patching module's default. Added the optional boolean to accommodate, updated README usage section.