### PR TITLE
v1.0.1: Improve handling of `patching_as_code_choco` fact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.1
+
+**Bugfixes**
+- Improved processing of the `patching_as_config_choco` fact, to ensure backwards compatibility with Facter 3.
+- The `patching_as_config_choco` fact now no longer errors on a system that does not have `patching_as_config` enabled.
 ## Release 1.0.0
 
 **Features**

--- a/lib/facter/patching_as_code_choco.rb
+++ b/lib/facter/patching_as_code_choco.rb
@@ -2,7 +2,13 @@
 Facter.add('patching_as_code_choco') do
   confine kernel: 'windows'
   setcode do
-    if Facter.value(:patching_as_code_config)['patch_choco'] == true
+    if Facter.fact(:patching_as_code_config) == nil
+      {
+        'package_update_count' => 0,
+        'packages' => [],
+        'pinned_packages' => []
+      }
+    elsif Facter.value(:patching_as_code_config)['patch_choco'] == true
       programdata = ENV['ProgramData']
       choco = "#{programdata}\\chocolatey\\bin\\choco.exe"
       output = if File.exist?(choco)

--- a/lib/facter/patching_as_code_choco.rb
+++ b/lib/facter/patching_as_code_choco.rb
@@ -20,14 +20,14 @@ Facter.add('patching_as_code_choco') do
       pinned = []
       # Determine Pinned packages (to be excluded from updating)
       output.each do |line|
-        data = line.split('|')
+        data = line.chomp.split('|')
         next if pinned.include? data[0].split('.')[0]
 
         pinned.push(data[0]) if data[3] == 'true'
       end
       # Determine packages to update
       output.each do |line|
-        data = line.split('|')
+        data = line.chomp.split('|')
         # Exclude subcomponents of packages
         next if pinned.include? data[0].split('.')[0]
         next if packages.include? data[0].split('.')[0]

--- a/lib/facter/patching_as_code_choco.rb
+++ b/lib/facter/patching_as_code_choco.rb
@@ -2,7 +2,7 @@
 Facter.add('patching_as_code_choco') do
   confine kernel: 'windows'
   setcode do
-    if Facter.fact(:patching_as_code_config) == nil
+    if Facter.fact(:patching_as_code_config).nil?
       {
         'package_update_count' => 0,
         'packages' => [],

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Bugfixes**
- Improved processing of the `patching_as_config_choco` fact, to ensure backwards compatibility with Facter 3.
- The `patching_as_config_choco` fact now no longer errors on a system that does not have `patching_as_config` enabled.