### PR TITLE
v1.0.2: Unique allow/block lists for Chocolatey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.2
+
+**Improvements**
+- Split the `allowlist` and `blacklist` to have dedicated lists for Chocolatey, with the new `allowlist_choco` and `blacklist_choco` parameters. These new parameters now must be used for Chocolatey packages, the regular `allowlist` and `blacklist` will not affect Chocolatey packages anymore.
+- Pending OS reboots will now no longer occur if `enable_patching` has been changed to `false`. This is to enable the `enable_patching` parameter being used as a single switch to ensure that no disruptive action can happen at all.
+
 ## Release 1.0.1
 
 **Bugfixes**
 - Improved processing of the `patching_as_config_choco` fact, to ensure backwards compatibility with Facter 3.
 - The `patching_as_config_choco` fact now no longer errors on a system that does not have `patching_as_config` enabled.
+
 ## Release 1.0.0
 
 **Features**

--- a/README.md
+++ b/README.md
@@ -158,12 +158,13 @@ patching_as_code::patch_schedule:
 
 ## Controlling which patches get installed
 
-If you need to limit which patches can get installed, use the blocklist/allowlist capabilties. This is best done through Hiera by defining an array values for `patching_as_code::blocklist` and/or `patching_as_code::allowlist`.
+If you need to limit which patches can get installed, use the blocklist/allowlist capabilties. This is best done through Hiera by defining an array values for `patching_as_code::blocklist` and/or `patching_as_code::allowlist` for Windows Updates and Linux packages. For Chocolatey packages, separate Hiera values `patching_as_code::blocklist_choco` and/or `patching_as_code::allowlist_choco` can be set.
 
 To prevent KB2881685 and the 7zip Chocolatey package from getting installed/updated on Windows:
 ```
 patching_as_code::blocklist:
   - KB2881685
+patching_as_code::blocklist_choco:
   - 7zip
 ```
 To only allow the patching of a specific set of 3 Linux packages:
@@ -173,7 +174,7 @@ patching_as_code::allowlist:
   - redis
   - nano
 ```
-Both options can be combined, in that case the list of available updates first gets reduced to the what is allowed by the allowlist, and then gets further reduced by any blocklisted updates.
+Allow lists and block lists can be combined, in that case the list of available updates first gets reduced to the what is allowed by the allowlist, and then gets further reduced by any blocklisted updates.
 
 ## Defining situations when patching needs to be skipped
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -40,6 +40,8 @@ patching_as_code::patch_schedule:
 
 patching_as_code::blocklist: []
 patching_as_code::allowlist: []
+patching_as_code::blocklist_choco: []
+patching_as_code::allowlist_choco: []
 patching_as_code::unsafe_process_list: []
 patching_as_code::pre_patch_commands: {}
 patching_as_code::post_patch_commands: {}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Improvements**
- Split the `allowlist` and `blacklist` to have dedicated lists for Chocolatey, with the new `allowlist_choco` and `blacklist_choco` parameters. These new parameters now must be used for Chocolatey packages, the regular `allowlist` and `blacklist` will not affect Chocolatey packages anymore.
- Pending OS reboots will now no longer occur if `enable_patching` has been changed to `false`. This is to enable the `enable_patching` parameter being used as a single switch to ensure that no disruptive action can happen at all.