### PR TITLE
remove chocolatey param to assume false

### DIFF
--- a/lib/puppet/type/patch_package.rb
+++ b/lib/puppet/type/patch_package.rb
@@ -12,6 +12,7 @@ Puppet::Type.newtype(:patch_package) do
 
   newparam(:chocolatey) do
     desc 'Whether this is a Chocolatey package (Windows only)'
+    defaultto :false
   end
 
   # All parameters are required

--- a/manifests/linux/patchday.pp
+++ b/manifests/linux/patchday.pp
@@ -38,7 +38,6 @@ class patching_as_code::linux::patchday (
   $updates.each | $package | {
     patch_package { $package:
       patch_window => 'Patching as Code - Patch Window',
-      chocolatey   => false,
       require      => Exec['Patching as Code - Clean Cache']
     }
   }


### PR DESCRIPTION
workaround:
`Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: no parameter named 'chocolatey' (file: /opt/puppet-code/environments/feature_introduce_patching/modules/patching_as_code/manifests/linux/patchday.pp, line: 39) on Patch_package[bash.x86_64] (file: /opt/puppet-code/environments/feature_introduce_patching/modules/patching_as_code/manifests/linux/patchday.pp, line: 39) on node [node](http://node/)`