### PR TITLE
v1.0.5: Use own location for `patching_as_code` fact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.5
+
+**Bugfixes**
+- Moves the location of the `patching_as_code` fact content to `/opt/puppetlabs/patching_as_code` (or `%ProgramData%\PuppetLabs\patching_as_code` on Windows), to remove a dependency on `pe_patch/os_patching` creating the directory where the last_run file content can be stored.
+- Fixes an incompatibility with `os_patching` that was caused by the wrong directory being assumed for the `patching_as_code` fact content when using `os_patching`.
+
 ## Release 1.0.4
 
 **Features**

--- a/lib/facter/patching_as_code.rb
+++ b/lib/facter/patching_as_code.rb
@@ -1,12 +1,13 @@
 Facter.add('patching_as_code') do
   setcode do
     directory = "#{Facter.value(:puppet_vardir)}/../../patching_as_code"
-    file = "#{directory}/last_run"
+    file      = "#{directory}/last_run"
+    oldfile   = "#{Facter.value(:puppet_vardir)}/../../pe_patch/patching_as_code_last_run"
     begin
       # Migrate fact if still in old location
-      if File.exist?("#{directory}/../pe_patch/patching_as_code_last_run")
+      if File.exist?(oldfile)
         Dir.mkdir(directory) unless Dir.exist?(directory)
-        File.rename "#{directory}/../pe_patch/patching_as_code_last_run", file
+        File.rename oldfile, file
       end
       if File.exist?(file)
         last_run = JSON.parse(File.read(file))

--- a/lib/facter/patching_as_code.rb
+++ b/lib/facter/patching_as_code.rb
@@ -1,18 +1,9 @@
 Facter.add('patching_as_code') do
   setcode do
-    option1 = "#{Facter.value(:puppet_vardir)}/../../pe_patch/patching_as_code_last_run"
-    option2 = "#{Facter.value(:puppet_vardir)}/../../os_patching/patching_as_code_last_run"
+    file = "#{Facter.value(:puppet_vardir)}/../../patching_as_code/last_run"
     begin
-      if File.exist?(option1)
+      if File.exist?(file)
         last_run = JSON.parse(File.read(option1))
-        result = {}
-        result['last_patch_run']            = last_run['last_run']
-        result['days_since_last_patch_run'] = (DateTime.now.to_date - DateTime.strptime(last_run['last_run'], '%Y-%m-%d %H:%M').to_date).to_i
-        result['patches_installed_on_last_run']         = last_run['patches_installed']
-        result['choco_patches_installed_on_last_run']   = last_run['choco_patches_installed']
-        result
-      elsif File.exist?(option2)
-        last_run = JSON.parse(File.read(option2))
         result = {}
         result['last_patch_run']            = last_run['last_run']
         result['days_since_last_patch_run'] = (DateTime.now.to_date - DateTime.strptime(last_run['last_run'], '%Y-%m-%d %H:%M').to_date).to_i

--- a/lib/facter/patching_as_code.rb
+++ b/lib/facter/patching_as_code.rb
@@ -1,7 +1,13 @@
 Facter.add('patching_as_code') do
   setcode do
-    file = "#{Facter.value(:puppet_vardir)}/../../patching_as_code/last_run"
+    directory = "#{Facter.value(:puppet_vardir)}/../../patching_as_code"
+    file = "#{directory}/last_run"
     begin
+      # Migrate fact if still in old location
+      if File.exist?("#{directory}/../pe_patch/patching_as_code_last_run")
+        Dir.mkdir(directory) unless Dir.exist?(directory)
+        File.rename "#{directory}/../pe_patch/patching_as_code_last_run", file
+      end
       if File.exist?(file)
         last_run = JSON.parse(File.read(file))
         result = {}

--- a/lib/facter/patching_as_code.rb
+++ b/lib/facter/patching_as_code.rb
@@ -3,7 +3,7 @@ Facter.add('patching_as_code') do
     file = "#{Facter.value(:puppet_vardir)}/../../patching_as_code/last_run"
     begin
       if File.exist?(file)
-        last_run = JSON.parse(File.read(option1))
+        last_run = JSON.parse(File.read(file))
         result = {}
         result['last_patch_run']            = last_run['last_run']
         result['days_since_last_patch_run'] = (DateTime.now.to_date - DateTime.strptime(last_run['last_run'], '%Y-%m-%d %H:%M').to_date).to_i

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -369,9 +369,11 @@ class patching_as_code(
               updates       => $updates_to_install.unique,
               choco_updates => $choco_updates_to_install.unique,
               require       => Anchor['patching_as_code::start']
+            } -> file {"${facts['puppet_vardir']}/../../patching_as_code":
+              ensure => directory
             } -> file {'Patching as Code - Save Patch Run Info':
               ensure    => file,
-              path      => "${facts['puppet_vardir']}/../../${patch_fact}/patching_as_code_last_run",
+              path      => "${facts['puppet_vardir']}/../../patching_as_code/last_run",
               show_diff => false,
               content   => Deferred('patching_as_code::last_run',[$updates_to_install, $choco_updates_to_install]),
             } -> notify {'Patching as Code - Update Fact':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
* Moves the location of the `patching_as_code` fact content to `/opt/puppetlabs/patching_as_code` (or `%ProgramData%\PuppetLabs\patching_as_code` on Windows), to remove a dependency on `pe_patch/os_patching` creating the directory where the last_run file content can be stored.
* Fixes an incompatibility with `os_patching` that was caused by the wrong directory being assumed for the `patching_as_code` fact content when using `os_patching`. Documented in #48 