### PR TITLE
v1.1.0: High priority patching support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.1.0
+
+**Features**
+- Adds support for high priority patches on an alternate patch schedule.
+- Adds `high_priority_only` parameter to the `patching_as_code` class, for compatibility with the `puppetlabs/change_window` module.
+
+**Improvements**
+- Ensures the last_run fact data only gets written during the patch window.
+
 ## Release 1.0.5
 
 **Bugfixes**

--- a/README.md
+++ b/README.md
@@ -211,7 +211,9 @@ else {
   }
 }
 ```
-This will allow `patching_as_code` to keep patch information up to date outside of the change window(s) defined by `puppetlabs/change_window`, and only perform regular patch runs when inside those change window(s). If you don't put any patches on the `high_priority_list`, running with `high_priority_only => true` will cause nothing to happen. Conversely, if you do need a high priority patch to be deployed, running with `high_priority_only => true` will allow those high priority patches to be installed. Use the patch schedule capabilities of `patching_as_code` to control when high priority patches are allowed to be installed, as documented above.
+This will allow `patching_as_code` to keep patch information up to date outside of the change window(s) defined by `puppetlabs/change_window`, and only perform regular patch runs when inside those change window(s). If you don't put any patches on the `high_priority_list`, running with `high_priority_only => true` will cause nothing to happen. Conversely, if you do need a high priority patch to be deployed, running with `high_priority_only => true` will allow those high priority patches to be installed. Use the patch schedule capabilities of `patching_as_code` to control when high priority patches are allowed to be installed, as well as whether reboots are allowed to happen at all.
+
+To assist with the use case of combining with `puppetlabs/change_window`, the `high_priority_only => true` setting, when used with a patch schedule that allows reboots, will skip acting on pre-existing pending OS reboots at the start of the patch run. This is to ensure a reboot only occurs after patching and only when at least 1 high priority patch was installed. No changes are made to the system this way unless absolutely necessary because of a high priority patch.
 
 ### Defining situations when patching needs to be skipped
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -74,6 +74,37 @@ Data type: `Array`
 
 List of updates that are allowed to be installed. Any updates not on this list get blocked.
 
+##### `blocklist_choco`
+
+Data type: `Array`
+
+List of Chocolatey updates to block from installing
+
+##### `allowlist_choco`
+
+Data type: `Array`
+
+List of Chocolatey updates that are allowed to be installed. Any Chocolatey updates not on this list get blocked.
+
+##### `high_priority_patch_group`
+
+Data type: `String`
+
+Name of the high_priority_patch_group for this node. Must match a patch group in `$patch_schedule`
+This patch schedule will only be used for patches in the `$high_priority_list`.
+
+##### `high_priority_list`
+
+Data type: `Array`
+
+List of updates to install on the patch schedule set by `$high_priority_patch_group`.
+
+##### `high_priority_list_choco`
+
+Data type: `Array`
+
+List of Chocolatey updates to install on the patch schedule set by `$high_priority_patch_group`.
+
 ##### `unsafe_process_list`
 
 Data type: `Array`
@@ -154,6 +185,17 @@ If patching of Chocolatey packages is enabled, Chocolatey packages will still up
 
 Default value: `false`
 
+##### `high_priority_only`
+
+Data type: `Optional[Boolean]`
+
+Only allow updates from the `$high_priority_list` to be installed. Enabling this option will prevent
+regular patches from being installed, and will skip a pending reboot at the beginning of the patch
+run if a pending reboot is detected. A pending reboot may still happen at the end of the patch run,
+as long as the patch schedule set by `$high_priority_patch_group` allows reboots to occur.
+
+Default value: `false`
+
 ##### `use_pe_patch`
 
 Data type: `Optional[Boolean]`
@@ -185,4 +227,3 @@ When enabled, patching are installed even over a metered link.
 When disabled (default), patches are not installed over a metered link.
 
 Default value: `false`
-

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -42,6 +42,8 @@ patching_as_code::blocklist: []
 patching_as_code::allowlist: []
 patching_as_code::blocklist_choco: []
 patching_as_code::allowlist_choco: []
+patching_as_code::high_priority_list: []
+patching_as_code::high_priority_list_choco: []
 patching_as_code::unsafe_process_list: []
 patching_as_code::pre_patch_commands: {}
 patching_as_code::post_patch_commands: {}

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,6 @@
 ---
 patching_as_code::patch_group: primary
+patching_as_code::high_priority_patch_group: never
 patching_as_code::patch_schedule:
   weekly:
     day_of_week: Thursday

--- a/functions/process_patch_groups.pp
+++ b/functions/process_patch_groups.pp
@@ -1,0 +1,81 @@
+function patching_as_code::process_patch_groups(
+){
+  if 'never' in $patching_as_code::patch_groups {
+    $bool_patch_day = false
+    schedule { 'Patching as Code - Patch Window':
+      period => 'never',
+    }
+    $reboot = 'never'
+    $active_pg = 'never'
+  } elsif 'always' in $patching_as_code::patch_groups {
+    $bool_patch_day = true
+    schedule { 'Patching as Code - Patch Window':
+      range  => '00:00 - 23:59',
+      repeat => 1440
+    }
+    $reboot = 'ifneeded'
+    $active_pg = 'always'
+  } else {
+    $pg_info = $patching_as_code::patch_groups.map |$pg| {
+      {
+        'name'         => $pg,
+        'is_patch_day' => patching_as_code::is_patchday(
+                            $patching_as_code::patch_schedule[$pg]['day_of_week'],
+                            $patching_as_code::patch_schedule[$pg]['count_of_week'],
+                            $pg
+                          )
+      }
+    }
+    $active_pg = $pg_info.reduce(undef) |$memo, $value| {
+      if $value['is_patch_day'] == true { $value['name'] } else { $memo }
+    }
+    $bool_patch_day = type($active_pg,'generalized') ? {
+      Type[String] => true,
+      default => false
+    }
+    if $bool_patch_day {
+      schedule { 'Patching as Code - Patch Window':
+        range  => $patching_as_code::patch_schedule[$active_pg]['hours'],
+        repeat => $patching_as_code::patch_schedule[$active_pg]['max_runs']
+      }
+      $reboot = $patching_as_code::patch_schedule[$active_pg]['reboot']
+    }
+  }
+
+  if $patching_as_code::high_priority_patch_group == 'never' {
+    $bool_high_prio_patch_day = false
+    schedule { 'Patching as Code - High Priority Patch Window':
+      period => 'never',
+    }
+    $high_prio_reboot = 'never'
+  } elsif $patching_as_code::high_priority_patch_group == 'always' {
+    $bool_high_prio_patch_day = true
+    schedule { 'Patching as Code - High Priority Patch Window':
+      range  => '00:00 - 23:59',
+      repeat => 1440
+    }
+    $high_prio_reboot = 'ifneeded'
+  } else {
+    $bool_high_prio_patch_day = patching_as_code::is_patchday(
+      $patching_as_code::patch_schedule[$patching_as_code::high_priority_patch_group]['day_of_week'],
+      $patching_as_code::patch_schedule[$patching_as_code::high_priority_patch_group]['count_of_week'],
+      $patching_as_code::high_priority_patch_group
+    )
+    if $bool_high_prio_patch_day {
+      schedule { 'Patching as Code - High Priority Patch Window':
+        range  => $patching_as_code::patch_schedule[$patching_as_code::high_priority_patch_group]['hours'],
+        repeat => $patching_as_code::patch_schedule[$patching_as_code::high_priority_patch_group]['max_runs']
+      }
+      $high_prio_reboot = $patching_as_code::patch_schedule[$patching_as_code::high_priority_patch_group]['reboot']
+    }
+  }
+
+  $result = {
+    'is_patch_day'           => $bool_patch_day,
+    'reboot'                 => $reboot,
+    'active_pg'              => $active_pg,
+    'is_high_prio_patch_day' => $bool_high_prio_patch_day,
+    'high_prio_reboot'       => $high_prio_reboot,
+  }
+  $result
+}

--- a/lib/facter/patching_as_code.rb
+++ b/lib/facter/patching_as_code.rb
@@ -1,30 +1,41 @@
 Facter.add('patching_as_code') do
   setcode do
-    directory = "#{Facter.value(:puppet_vardir)}/../../patching_as_code"
-    file      = "#{directory}/last_run"
-    oldfile   = "#{Facter.value(:puppet_vardir)}/../../pe_patch/patching_as_code_last_run"
+    directory      = "#{Facter.value(:puppet_vardir)}/../../patching_as_code"
+    file           = "#{directory}/last_run"
+    high_prio_file = "#{directory}/high_prio_last_run"
+    oldfile        = "#{Facter.value(:puppet_vardir)}/../../pe_patch/patching_as_code_last_run"
     begin
-      # Migrate fact if still in old location
+      # Migrate last_run file if still in old location
       if File.exist?(oldfile)
         Dir.mkdir(directory) unless Dir.exist?(directory)
         File.rename oldfile, file
       end
-      if File.exist?(file)
-        last_run = JSON.parse(File.read(file))
-        result = {}
-        result['last_patch_run']            = last_run['last_run']
-        result['days_since_last_patch_run'] = (DateTime.now.to_date - DateTime.strptime(last_run['last_run'], '%Y-%m-%d %H:%M').to_date).to_i
+      last_run           = JSON.parse(File.read(file)) if File.exist?(file)
+      high_prio_last_run = JSON.parse(File.read(high_prio_file)) if File.exist?(high_prio_file)
+      result = {}
+      if defined?(last_run)
+        result['last_patch_run']                        = last_run['last_run']
+        result['days_since_last_patch_run']             = (DateTime.now.to_date - DateTime.strptime(last_run['last_run'], '%Y-%m-%d %H:%M').to_date).to_i
         result['patches_installed_on_last_run']         = last_run['patches_installed']
         result['choco_patches_installed_on_last_run']   = last_run['choco_patches_installed']
-        result
       else
-        {
-          'last_patch_run' => '',
-          'days_since_last_patch_run' => 0,
-          'patches_installed_on_last_run' => [],
-          'choco_patches_installed_on_last_run' => []
-        }
+        result['last_patch_run']                        = ''
+        result['days_since_last_patch_run']             = 0
+        result['patches_installed_on_last_run']         = []
+        result['choco_patches_installed_on_last_run']   = []
       end
+      if defined?(high_prio_last_run)
+        result['last_high_prio_patch_run']                      = high_prio_last_run['last_run']
+        result['days_since_last_high_prio_patch_run']           = (DateTime.now.to_date - DateTime.strptime(high_prio_last_run['last_run'], '%Y-%m-%d %H:%M').to_date).to_i
+        result['patches_installed_on_last_high_prio_run']       = high_prio_last_run['patches_installed']
+        result['choco_patches_installed_on_last_high_prio_run'] = high_prio_last_run['choco_patches_installed']
+      else
+        result['last_high_prio_patch_run']                      = ''
+        result['days_since_last_high_prio_patch_run']           = 0
+        result['patches_installed_on_last_high_prio_run']       = []
+        result['choco_patches_installed_on_last_high_prio_run'] = []
+      end
+      result
     rescue
       {
         'last_patch_run' => '',

--- a/lib/facter/patching_as_code.rb
+++ b/lib/facter/patching_as_code.rb
@@ -13,35 +13,39 @@ Facter.add('patching_as_code') do
       last_run           = JSON.parse(File.read(file)) if File.exist?(file)
       high_prio_last_run = JSON.parse(File.read(high_prio_file)) if File.exist?(high_prio_file)
       result = {}
-      if defined?(last_run)
-        result['last_patch_run']                        = last_run['last_run']
-        result['days_since_last_patch_run']             = (DateTime.now.to_date - DateTime.strptime(last_run['last_run'], '%Y-%m-%d %H:%M').to_date).to_i
-        result['patches_installed_on_last_run']         = last_run['patches_installed']
-        result['choco_patches_installed_on_last_run']   = last_run['choco_patches_installed']
-      else
+      if last_run.nil?
         result['last_patch_run']                        = ''
         result['days_since_last_patch_run']             = 0
         result['patches_installed_on_last_run']         = []
         result['choco_patches_installed_on_last_run']   = []
-      end
-      if defined?(high_prio_last_run)
-        result['last_high_prio_patch_run']                      = high_prio_last_run['last_run']
-        result['days_since_last_high_prio_patch_run']           = (DateTime.now.to_date - DateTime.strptime(high_prio_last_run['last_run'], '%Y-%m-%d %H:%M').to_date).to_i
-        result['patches_installed_on_last_high_prio_run']       = high_prio_last_run['patches_installed']
-        result['choco_patches_installed_on_last_high_prio_run'] = high_prio_last_run['choco_patches_installed']
       else
+        result['last_patch_run']                        = last_run['last_run']
+        result['days_since_last_patch_run']             = (DateTime.now.to_date - DateTime.strptime(last_run['last_run'], '%Y-%m-%d %H:%M').to_date).to_i
+        result['patches_installed_on_last_run']         = last_run['patches_installed']
+        result['choco_patches_installed_on_last_run']   = last_run['choco_patches_installed']
+      end
+      if high_prio_last_run.nil?
         result['last_high_prio_patch_run']                      = ''
         result['days_since_last_high_prio_patch_run']           = 0
         result['patches_installed_on_last_high_prio_run']       = []
         result['choco_patches_installed_on_last_high_prio_run'] = []
+      else
+        result['last_high_prio_patch_run']                      = high_prio_last_run['last_run']
+        result['days_since_last_high_prio_patch_run']           = (DateTime.now.to_date - DateTime.strptime(high_prio_last_run['last_run'], '%Y-%m-%d %H:%M').to_date).to_i
+        result['patches_installed_on_last_high_prio_run']       = high_prio_last_run['patches_installed']
+        result['choco_patches_installed_on_last_high_prio_run'] = high_prio_last_run['choco_patches_installed']
       end
       result
     rescue
       {
-        'last_patch_run' => '',
-        'days_since_last_patch_run' => 0,
-        'patches_installed_on_last_run' => [],
-        'choco_patches_installed_on_last_run' => []
+        'last_patch_run'                                => '',
+        'days_since_last_patch_run'                     => 0,
+        'patches_installed_on_last_run'                 => [],
+        'choco_patches_installed_on_last_run'           => [],
+        'last_high_prio_patch_run'                      => '',
+        'days_since_last_high_prio_patch_run'           => 0,
+        'patches_installed_on_last_high_prio_run'       => [],
+        'choco_patches_installed_on_last_high_prio_run' => []
       }
     end
   end

--- a/lib/puppet/functions/patching_as_code/high_prio_last_run.rb
+++ b/lib/puppet/functions/patching_as_code/high_prio_last_run.rb
@@ -1,0 +1,14 @@
+Puppet::Functions.create_function(:'patching_as_code::high_prio_last_run') do
+  dispatch :high_prio_last_run do
+    param 'Array', :patches
+    param 'Array', :choco_patches
+  end
+
+  def high_prio_last_run(patches, choco_patches)
+    {
+      'last_run' => Time.now.strftime('%Y-%m-%d %H:%M'),
+      'patches_installed' => patches,
+      'choco_patches_installed' => choco_patches,
+    }.to_json
+  end
+end

--- a/manifests/high_prio_reboot.pp
+++ b/manifests/high_prio_reboot.pp
@@ -1,0 +1,45 @@
+# Class: patching_as_code::high_prio_reboot
+#
+#
+class patching_as_code::high_prio_reboot(
+  Boolean $reboot_if_needed = true,
+  Integer $reboot_delay = 120
+) {
+  $reboot_delay_min = round($reboot_delay / 60)
+  if $reboot_if_needed {
+    # Define an Exec to perform the reboot shortly after the Puppet run completes
+    case $facts['kernel'].downcase() {
+      'windows': {
+        $reboot_logic_provider = 'powershell'
+        $reboot_logic_cmd      = "& shutdown /r /t ${reboot_delay} /c \"Patching_as_code: Rebooting system due to a pending reboot after patching\" /d p:2:17" # lint:ignore:140chars 
+        $reboot_logic_onlyif   = "${facts['puppet_vardir']}/lib/patching_as_code/pending_reboot.ps1 | findstr -i True"
+      }
+      'linux': {
+        $reboot_logic_provider = 'posix'
+        $reboot_logic_cmd      = "/sbin/shutdown -r +${reboot_delay_min}"
+        $reboot_logic_onlyif   = "/bin/sh ${facts['puppet_vardir']}/lib/patching_as_code/pending_reboot.sh | grep true"
+      }
+      default: {
+        fail('Unsupported operating system for Patching as Code!')
+      }
+    }
+    exec {'Patching as Code - High Priority Patch Reboot':
+      command   => $reboot_logic_cmd,
+      onlyif    => $reboot_logic_onlyif,
+      provider  => $reboot_logic_provider,
+      logoutput => true,
+      schedule  => 'Patching as Code - High Priority Patch Window',
+    }
+  } else {
+    # Reboot as part of this Puppet run
+    reboot { 'Patching as Code - High Priority Patch Reboot':
+      apply    => 'immediately',
+      schedule => 'Patching as Code - High Priority Patch Window',
+      timeout  => $reboot_delay,
+    }
+    notify { 'Patching as Code - Performing OS reboot (High Priority)':
+      notify   => Reboot['Patching as Code - High Priority Patch Reboot'],
+      schedule => 'Patching as Code - High Priority Patch Window',
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -563,7 +563,7 @@ class patching_as_code(
                   fail('Unsupported operating system for Patching as Code!')
                 }
               }
-              if $reboot and $bool_patch_day {
+              if $reboot and $bool_patch_day and !$high_priority_only {
                 $pre_reboot_commands.each | $cmd, $cmd_opts | {
                   exec { "Patching as Code - Before reboot - ${cmd}":
                     *        => delete($cmd_opts, ['provider', 'onlyif', 'unless', 'require', 'before', 'schedule', 'tag']),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,6 +99,9 @@ class patching_as_code(
   Array                         $allowlist,
   Array                         $blocklist_choco,
   Array                         $allowlist_choco,
+  String                        $high_priority_patch_group,
+  Array                         $high_priority_list,
+  Array                         $high_priority_list_choco,
   Array                         $unsafe_process_list,
   Hash                          $pre_patch_commands,
   Hash                          $post_patch_commands,
@@ -107,6 +110,7 @@ class patching_as_code(
   Optional[String]              $plan_patch_fact = undef,
   Optional[Boolean]             $enable_patching = true,
   Optional[Boolean]             $security_only = false,
+  Optional[Boolean]             $high_priority_only = false,
   Optional[Boolean]             $patch_choco = false,
   Optional[Boolean]             $use_pe_patch = true,
   Optional[Boolean]             $classify_pe_patch = false,
@@ -125,6 +129,12 @@ class patching_as_code(
       fail("Patch group ${pg} is not valid as no associated schedule was found!
       Ensure the patching_as_code::patch_schedule parameter contains a schedule for this patch group.")
     }
+  }
+
+  # Verify if the $high_priority_patch_group points to a valid patch schedule
+  unless $patch_schedule[$high_priority_patch_group] or $high_priority_patch_group in ['always', 'never'] {
+    fail("High Priority Patch group ${high_priority_patch_group} is not valid as no associated schedule was found!
+    Ensure the patching_as_code::patch_schedule parameter contains a schedule for this patch group.")
   }
 
   # Verify the puppet_confdir from the puppetlabs/puppet_agent module is present
@@ -191,48 +201,13 @@ class patching_as_code(
     ensure_packages('yum-utils')
   }
 
-  # Determine if today is Patch Day for this node's $patch_groups
-  if 'never' in $patch_groups {
-    $bool_patch_day = false
-    schedule { 'Patching as Code - Patch Window':
-      period => 'never',
-    }
-    $_reboot = 'never'
-    $active_pg = 'never'
-  } elsif 'always' in $patch_groups {
-    $bool_patch_day = true
-    schedule { 'Patching as Code - Patch Window':
-      range  => '00:00 - 23:59',
-      repeat => 1440
-    }
-    $_reboot = 'ifneeded'
-    $active_pg = 'always'
-  } else {
-    $pg_info = $patch_groups.map |$pg| {
-      {
-        'name'         => $pg,
-        'is_patch_day' => patching_as_code::is_patchday(
-                            $patch_schedule[$pg]['day_of_week'],
-                            $patch_schedule[$pg]['count_of_week'],
-                            $pg
-                          )
-      }
-    }
-    $active_pg = $pg_info.reduce(undef) |$memo, $value| {
-      if $value['is_patch_day'] == true { $value['name'] } else { $memo }
-    }
-    $bool_patch_day = type($active_pg,'generalized') ? {
-      Type[String] => true,
-      default => false
-    }
-    if $bool_patch_day {
-      schedule { 'Patching as Code - Patch Window':
-        range  => $patch_schedule[$active_pg]['hours'],
-        repeat => $patch_schedule[$active_pg]['max_runs']
-      }
-      $_reboot = $patch_schedule[$active_pg]['reboot']
-    }
-  }
+  # Determine if today is Patch Day for this node's $patch_groups and $high_priority_patch_group
+  $result = patching_as_code::process_patch_groups()
+  $bool_patch_day           = $result['is_patch_day']
+  $_reboot                  = $result['reboot']
+  $_high_prio_reboot        = $result['high_prio_reboot']
+  $active_pg                = $result['active_pg']
+  $bool_high_prio_patch_day = $result['is_high_prio_patch_day']
 
   # Write local state file for config reporting and reuse in plans
   file { 'patching_configuration.json':
@@ -240,53 +215,85 @@ class patching_as_code(
     path      => "${facts['puppet_vardir']}/../../facter/facts.d/patching_configuration.json",
     content   => to_json_pretty({
       patching_as_code_config => {
-        allowlist              => $allowlist,
-        blocklist              => $blocklist,
-        allowlist_choco        => $allowlist_choco,
-        blocklist_choco        => $blocklist_choco,
-        enable_patching        => $enable_patching,
-        patch_fact             => $patch_fact,
-        patch_group            => $patch_groups,
-        patch_schedule         => if $active_pg in ['always', 'never'] {
+        allowlist                 => $allowlist,
+        blocklist                 => $blocklist,
+        high_priority_list        => $high_priority_list,
+        allowlist_choco           => $allowlist_choco,
+        blocklist_choco           => $blocklist_choco,
+        high_priority_list_choco  => $high_priority_list_choco,
+        enable_patching           => $enable_patching,
+        patch_fact                => $patch_fact,
+        patch_group               => $patch_groups,
+        patch_schedule            => if $active_pg in ['always', 'never'] {
                                     { $active_pg => 'N/A' }
                                   } else {
                                     $patch_schedule.filter |$item| { $item[0] in $patch_groups }
                                   },
-        post_patch_commands    => $post_patch_commands,
-        pre_patch_commands     => $pre_patch_commands,
-        pre_reboot_commands    => $pre_reboot_commands,
-        patch_on_metered_links => $patch_on_metered_links,
-        security_only          => $security_only,
-        patch_choco            => $patch_choco,
-        unsafe_process_list    => $unsafe_process_list,
+        high_priority_patch_group => $high_priority_patch_group,
+        post_patch_commands       => $post_patch_commands,
+        pre_patch_commands        => $pre_patch_commands,
+        pre_reboot_commands       => $pre_reboot_commands,
+        patch_on_metered_links    => $patch_on_metered_links,
+        security_only             => $security_only,
+        patch_choco               => $patch_choco,
+        unsafe_process_list       => $unsafe_process_list,
       }
     }, false),
     show_diff => false
   }
 
-  if $bool_patch_day {
+  if $bool_patch_day or $bool_high_prio_patch_day {
     if $facts[$patch_fact] {
       $available_updates = $facts['kernel'] ? {
-        'windows' =>  if $security_only == true {
+        'windows' =>  if $bool_patch_day and $security_only and !$high_priority_only {
                         unless $facts[$patch_fact]['missing_security_kbs'].empty {
                           $facts[$patch_fact]['missing_security_kbs']
                         } else {
                           $facts[$patch_fact]['missing_update_kbs']
                         }
-                      } else {
+                      } elsif $bool_patch_day and !$high_priority_only {
                         $facts[$patch_fact]['missing_update_kbs']
-                      },
-        'Linux'   =>  if $security_only == true {
-                        $facts[$patch_fact]['security_package_updates']
                       } else {
+                        []
+                      },
+        'Linux'   =>  if $bool_patch_day and $security_only and !$high_priority_only{
+                        $facts[$patch_fact]['security_package_updates']
+                      } elsif $bool_patch_day and !$high_priority_only{
                         $facts[$patch_fact]['package_updates']
+                      } else {
+                        []
                       },
         default   => []
       }
       $choco_updates = $facts['kernel'] ? {
-        'windows' =>  if $patch_choco == true {
+        'windows' =>  if $bool_patch_day and $patch_choco and !$high_priority_only {
                         if $facts['patching_as_code_choco'] {
                           $facts['patching_as_code_choco']['packages']
+                        } else {
+                          []
+                        }
+                      } else {
+                        []
+                      },
+        default   => []
+      }
+      $high_prio_updates = $facts['kernel'] ? {
+        'windows' =>  if $bool_high_prio_patch_day {
+                        $facts[$patch_fact]['missing_update_kbs'].filter |$item| { $item in $high_priority_list }
+                      } else {
+                        []
+                      },
+        'Linux'   =>  if $bool_high_prio_patch_day {
+                        $facts[$patch_fact]['package_updates'].filter |$item| { $item in $high_priority_list }
+                      } else {
+                        []
+                      },
+        default   => []
+      }
+      $high_prio_updates_choco = $facts['kernel'] ? {
+        'windows' =>  if $bool_high_prio_patch_day and $patch_choco == true {
+                        if $facts['patching_as_code_choco'] {
+                          $facts['patching_as_code_choco']['packages'].filter |$item| { $item in $high_priority_list_choco }
                         } else {
                           []
                         }
@@ -299,25 +306,51 @@ class patching_as_code(
     else {
       $available_updates = []
       $choco_updates = []
+      $high_prio_updates = []
+      $high_prio_updates_choco = []
     }
 
     case $allowlist.count {
       0: {
-        $updates_to_install       = $available_updates.filter |$item| { !($item in $blocklist) }
+        $_updates_to_install          = $available_updates.filter |$item| { !($item in $blocklist) }
+        $high_prio_updates_to_install = $high_prio_updates.filter |$item| { !($item in $blocklist) }
+        if ($bool_patch_day and $bool_high_prio_patch_day) {
+          $updates_to_install = $_updates_to_install.filter |$item| { !($item in $high_prio_updates_to_install) }
+        } else {
+          $updates_to_install = $_updates_to_install
+        }
       }
       default: {
-        $whitelisted_updates       =         $available_updates.filter |$item| { $item in $allowlist }
-        $updates_to_install        =       $whitelisted_updates.filter |$item| { !($item in $blocklist) }
+        $whitelisted_updates          =   $available_updates.filter |$item| { $item in $allowlist }
+        $_updates_to_install          = $whitelisted_updates.filter |$item| { !($item in $blocklist) }
+        $high_prio_updates_to_install =   $high_prio_updates.filter |$item| { !($item in $blocklist) }
+        if ($bool_patch_day and $bool_high_prio_patch_day) {
+          $updates_to_install = $_updates_to_install.filter |$item| { !($item in $high_prio_updates_to_install) }
+        } else {
+          $updates_to_install = $_updates_to_install
+        }
       }
     }
 
     case $allowlist_choco.count {
       0: {
-        $choco_updates_to_install =     $choco_updates.filter |$item| { !($item in $blocklist_choco) }
+        $_choco_updates_to_install          =           $choco_updates.filter |$item| { !($item in $blocklist_choco) }
+        $high_prio_choco_updates_to_install = $high_prio_updates_choco.filter |$item| { !($item in $blocklist_choco) }
+        if ($bool_patch_day and $bool_high_prio_patch_day) {
+          $choco_updates_to_install = $_choco_updates_to_install.filter |$item| { !($item in $high_prio_choco_updates_to_install) }
+        } else {
+          $choco_updates_to_install = $_choco_updates_to_install
+        }
       }
       default: {
-        $whitelisted_choco_updates =             $choco_updates.filter |$item| { $item in $allowlist_choco }
-        $choco_updates_to_install  = $whitelisted_choco_updates.filter |$item| { !($item in $blocklist_choco) }
+        $whitelisted_choco_updates          =             $choco_updates.filter |$item| { $item in $allowlist_choco }
+        $_choco_updates_to_install          = $whitelisted_choco_updates.filter |$item| { !($item in $blocklist_choco) }
+        $high_prio_choco_updates_to_install =   $high_prio_updates_choco.filter |$item| { !($item in $blocklist_choco) }
+        if ($bool_patch_day and $bool_high_prio_patch_day) {
+          $choco_updates_to_install = $_choco_updates_to_install.filter |$item| { !($item in $high_prio_choco_updates_to_install) }
+        } else {
+          $choco_updates_to_install = $_choco_updates_to_install
+        }
       }
     }
 
@@ -331,8 +364,19 @@ class patching_as_code(
       'ifneeded': {true}
       default:    {false}
     }
-    if $reboot and $enable_patching {
-      # Reboot the node first if a reboot is already pending
+    $high_prio_reboot = case $_high_prio_reboot {
+      'always':   {true}
+      'never':    {false}
+      'ifneeded': {true}
+      default:    {false}
+    }
+    $high_prio_reboot_if_needed = case $_high_prio_reboot {
+      'ifneeded': {true}
+      default:    {false}
+    }
+
+    if $reboot and $enable_patching and !$high_priority_only {
+      # Reboot the node first if a reboot is already pending, except if this is a high prio only run
       case $facts['kernel'].downcase() {
         /(windows|linux)/: {
           reboot_if_pending {'Patching as Code':
@@ -347,17 +391,31 @@ class patching_as_code(
     }
     anchor {'patching_as_code::start':}
 
-    if ($updates_to_install.count + $choco_updates_to_install.count > 0) and ($enable_patching == true) {
+    if ($updates_to_install.count + $choco_updates_to_install.count +
+    $high_prio_updates_to_install.count + $high_prio_choco_updates_to_install.count > 0) and
+    ($enable_patching == true) {
       if (($patch_on_metered_links == true) or (! $facts['metered_link'] == true)) and (! $facts['patch_unsafe_process_active'] == true) {
         case $facts['kernel'].downcase() {
           /(windows|linux)/: {
             # Run pre-patch commands if provided
-            $pre_patch_commands.each | $cmd, $cmd_opts | {
-              exec { "Patching as Code - Before patching - ${cmd}":
-                *        => delete($cmd_opts, ['before', 'schedule', 'tag']),
-                before   => Class["patching_as_code::${0}::patchday"],
-                schedule => 'Patching as Code - Patch Window',
-                tag      => ['patching_as_code_pre_patching']
+            if ($updates_to_install.count + $choco_updates_to_install.count > 0) {
+              $pre_patch_commands.each | $cmd, $cmd_opts | {
+                exec { "Patching as Code - Before patching - ${cmd}":
+                  *        => delete($cmd_opts, ['before', 'schedule', 'tag']),
+                  before   => Class["patching_as_code::${0}::patchday"],
+                  schedule => 'Patching as Code - Patch Window',
+                  tag      => ['patching_as_code_pre_patching']
+                }
+              }
+            }
+            if ($high_prio_updates_to_install.count + $high_prio_choco_updates_to_install.count > 0) {
+              $pre_patch_commands.each | $cmd, $cmd_opts | {
+                exec { "Patching as Code - Before patching (High Priority) - ${cmd}":
+                  *        => delete($cmd_opts, ['before', 'schedule', 'tag']),
+                  before   => Class["patching_as_code::${0}::patchday"],
+                  schedule => 'Patching as Code - High Priority Patch Window',
+                  tag      => ['patching_as_code_pre_patching']
+                }
               }
             }
             # Perform main patching run
@@ -366,36 +424,76 @@ class patching_as_code(
               false => Exec["${patch_fact}::exec::fact"]
             }
             class { "patching_as_code::${0}::patchday":
-              updates       => $updates_to_install.unique,
-              choco_updates => $choco_updates_to_install.unique,
-              require       => Anchor['patching_as_code::start']
+              updates                 => $updates_to_install.unique,
+              choco_updates           => $choco_updates_to_install.unique,
+              high_prio_updates       => $high_prio_updates_to_install.unique,
+              high_prio_choco_updates => $high_prio_choco_updates_to_install.unique,
+              require                 => Anchor['patching_as_code::start']
             } -> file {"${facts['puppet_vardir']}/../../patching_as_code":
               ensure => directory
             } -> file {'Patching as Code - Save Patch Run Info':
               ensure    => file,
               path      => "${facts['puppet_vardir']}/../../patching_as_code/last_run",
               show_diff => false,
-              content   => Deferred('patching_as_code::last_run',[$updates_to_install, $choco_updates_to_install]),
+              content   => Deferred('patching_as_code::last_run',[
+                $updates_to_install,
+                $choco_updates_to_install
+              ]),
+              schedule  => 'Patching as Code - Patch Window',
+            } -> file {'Patching as Code - Save High Priority Patch Run Info':
+              ensure    => file,
+              path      => "${facts['puppet_vardir']}/../../patching_as_code/high_prio_last_run",
+              show_diff => false,
+              content   => Deferred('patching_as_code::high_prio_last_run',[
+                $high_prio_updates_to_install,
+                $high_prio_choco_updates_to_install
+              ]),
+              schedule  => 'Patching as Code - High Priority Patch Window',
             } -> notify {'Patching as Code - Update Fact':
               message  => 'Patches installed, refreshing patching facts...',
               notify   => $patch_refresh_actions,
               schedule => 'Patching as Code - Patch Window',
+            } -> notify {'Patching as Code - Update Fact (High Priority)':
+              message  => 'Patches installed, refreshing patching facts...',
+              notify   => $patch_refresh_actions,
+              schedule => 'Patching as Code - High Priority Patch Window',
             }
-            if $reboot {
+            if $reboot or $high_prio_reboot {
               # Reboot after patching (in later patch_reboot stage)
-              class { 'patching_as_code::reboot':
-                reboot_if_needed => $reboot_if_needed,
-                schedule         => 'Patching as Code - Patch Window',
-                stage            => patch_reboot
+              if ($updates_to_install.count + $choco_updates_to_install.count > 0) and $reboot {
+                class { 'patching_as_code::reboot':
+                  reboot_if_needed => $reboot_if_needed,
+                  schedule         => 'Patching as Code - Patch Window',
+                  stage            => patch_reboot
+                }
+              }
+              if ($high_prio_updates_to_install.count + $high_prio_choco_updates_to_install.count > 0) and $high_prio_reboot {
+                class { 'patching_as_code::high_prio_reboot':
+                  reboot_if_needed => $reboot_if_needed,
+                  schedule         => 'Patching as Code - High Priority Patch Window',
+                  stage            => patch_reboot
+                }
               }
               # Perform post-patching Execs
-              $post_patch_commands.each | $cmd, $cmd_opts | {
-                exec { "Patching as Code - After patching - ${cmd}":
-                  *        => delete($cmd_opts, ['require', 'before', 'schedule', 'tag']),
-                  require  => Class["patching_as_code::${0}::patchday"],
-                  schedule => 'Patching as Code - Patch Window',
-                  tag      => ['patching_as_code_post_patching']
-                } -> Exec <| tag == 'patching_as_code_pre_reboot' |>
+              if ($updates_to_install.count + $choco_updates_to_install.count > 0) and $reboot {
+                $post_patch_commands.each | $cmd, $cmd_opts | {
+                  exec { "Patching as Code - After patching - ${cmd}":
+                    *        => delete($cmd_opts, ['require', 'before', 'schedule', 'tag']),
+                    require  => Class["patching_as_code::${0}::patchday"],
+                    schedule => 'Patching as Code - Patch Window',
+                    tag      => ['patching_as_code_post_patching']
+                  } -> Exec <| tag == 'patching_as_code_pre_reboot' |>
+                }
+              }
+              if ($high_prio_updates_to_install.count + $high_prio_choco_updates_to_install.count > 0) and $high_prio_reboot {
+                $post_patch_commands.each | $cmd, $cmd_opts | {
+                  exec { "Patching as Code - After patching (High Priority) - ${cmd}":
+                    *        => delete($cmd_opts, ['require', 'before', 'schedule', 'tag']),
+                    require  => Class["patching_as_code::${0}::patchday"],
+                    schedule => 'Patching as Code - High Priority Patch Window',
+                    tag      => ['patching_as_code_post_patching']
+                  } -> Exec <| tag == 'patching_as_code_pre_reboot' |>
+                }
               }
               # Define pre-reboot Execs
               case $facts['kernel'].downcase() {
@@ -417,24 +515,50 @@ class patching_as_code(
                   fail('Unsupported operating system for Patching as Code!')
                 }
               }
-              $pre_reboot_commands.each | $cmd, $cmd_opts | {
-                exec { "Patching as Code - Before reboot - ${cmd}":
-                  *        => delete($cmd_opts, ['provider', 'onlyif', 'unless', 'require', 'before', 'schedule', 'tag']),
-                  provider => $reboot_logic_provider,
-                  onlyif   => $reboot_logic_onlyif,
-                  require  => Class["patching_as_code::${0}::patchday"],
-                  schedule => 'Patching as Code - Patch Window',
-                  tag      => ['patching_as_code_pre_reboot']
+              if ($updates_to_install.count + $choco_updates_to_install.count > 0) and $reboot {
+                $pre_reboot_commands.each | $cmd, $cmd_opts | {
+                  exec { "Patching as Code - Before reboot - ${cmd}":
+                    *        => delete($cmd_opts, ['provider', 'onlyif', 'unless', 'require', 'before', 'schedule', 'tag']),
+                    provider => $reboot_logic_provider,
+                    onlyif   => $reboot_logic_onlyif,
+                    require  => Class["patching_as_code::${0}::patchday"],
+                    schedule => 'Patching as Code - Patch Window',
+                    tag      => ['patching_as_code_pre_reboot']
+                  }
+                }
+              }
+              if ($high_prio_updates_to_install.count + $high_prio_choco_updates_to_install.count > 0) and $high_prio_reboot {
+                $pre_reboot_commands.each | $cmd, $cmd_opts | {
+                  exec { "Patching as Code - Before reboot (High Priority) - ${cmd}":
+                    *        => delete($cmd_opts, ['provider', 'onlyif', 'unless', 'require', 'before', 'schedule', 'tag']),
+                    provider => $reboot_logic_provider,
+                    onlyif   => $reboot_logic_onlyif,
+                    require  => Class["patching_as_code::${0}::patchday"],
+                    schedule => 'Patching as Code - High Priority Patch Window',
+                    tag      => ['patching_as_code_pre_reboot']
+                  }
                 }
               }
             } else {
               # Do not reboot after patching, just run post_patch commands if given
-              $post_patch_commands.each | $cmd, $cmd_opts | {
-                exec { "Patching as Code - After patching - ${cmd}":
-                  *        => delete($cmd_opts, ['require', 'schedule', 'tag']),
-                  require  => Class["patching_as_code::${0}::patchday"],
-                  schedule => 'Patching as Code - Patch Window',
-                  tag      => ['patching_as_code_post_patching']
+              if ($updates_to_install.count + $choco_updates_to_install.count > 0) {
+                $post_patch_commands.each | $cmd, $cmd_opts | {
+                  exec { "Patching as Code - After patching - ${cmd}":
+                    *        => delete($cmd_opts, ['require', 'schedule', 'tag']),
+                    require  => Class["patching_as_code::${0}::patchday"],
+                    schedule => 'Patching as Code - Patch Window',
+                    tag      => ['patching_as_code_post_patching']
+                  }
+                }
+              }
+              if ($high_prio_updates_to_install.count + $high_prio_choco_updates_to_install.count > 0) {
+                $post_patch_commands.each | $cmd, $cmd_opts | {
+                  exec { "Patching as Code - After patching (High Priority)- ${cmd}":
+                    *        => delete($cmd_opts, ['require', 'schedule', 'tag']),
+                    require  => Class["patching_as_code::${0}::patchday"],
+                    schedule => 'Patching as Code - High Priority Patch Window',
+                    tag      => ['patching_as_code_post_patching']
+                  }
                 }
               }
             }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -389,7 +389,7 @@ class patching_as_code(
 
     # Perform pending reboots pre-patching, except if this is a high prio only run
     if $enable_patching and !$high_priority_only {
-      if ($reboot and ($updates_to_install.count + $choco_updates_to_install.count > 0)) {
+      if $reboot and $bool_patch_day {
         # Reboot the node first if a reboot is already pending
         case $facts['kernel'].downcase() {
           /(windows|linux)/: {
@@ -403,7 +403,7 @@ class patching_as_code(
           }
         }
       }
-      if ($high_prio_reboot and ($high_prio_updates_to_install.count + $high_prio_choco_updates_to_install.count > 0)) {
+      if $high_prio_reboot and $bool_high_prio_patch_day {
         # Reboot the node first if a reboot is already pending
         case $facts['kernel'].downcase() {
           /(windows|linux)/: {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -403,7 +403,8 @@ class patching_as_code(
           }
         }
       }
-      if $high_prio_reboot and $bool_high_prio_patch_day {
+      if $high_prio_reboot and $bool_high_prio_patch_day and
+      ($high_prio_updates_to_install.count + $high_prio_choco_updates_to_install.count > 0){
         # Reboot the node first if a reboot is already pending
         case $facts['kernel'].downcase() {
           /(windows|linux)/: {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,13 @@
 #   List of Chocolatey updates to block from installing
 # @param [Array] allowlist_choco
 #   List of Chocolatey updates that are allowed to be installed. Any Chocolatey updates not on this list get blocked.
+# @param [String] high_priority_patch_group
+#   Name of the high_priority_patch_group for this node. Must match a patch group in `$patch_schedule`
+#   This patch schedule will only be used for patches in the `$high_priority_list`.
+# @param [Array] high_priority_list
+#   List of updates to install on the patch schedule set by `$high_priority_patch_group`.
+# @param [Array] high_priority_list_choco
+#   List of Chocolatey updates to install on the patch schedule set by `$high_priority_patch_group`.
 # @param [Array] unsafe_process_list
 #   List of processes that will cause patching to be skipped if any of the processes in the list are active on the system.
 # @param [Hash] pre_patch_commands
@@ -77,6 +84,11 @@
 #   When using `os_patching`, security updates can only be applied to Linux.
 #   If patching of Chocolatey packages is enabled, those packages will still update even if
 #   `security_only` is set to `true`.
+# @param [Optional[Boolean]] high_priority_only
+#   Only allow updates from the `$high_priority_list` to be installed. Enabling this option will prevent
+#   regular patches from being installed, and will skip a pending reboot at the beginning of the patch
+#   run if a pending reboot is detected. A pending reboot may still happen at the end of the patch run,
+#   as long as the patch schedule set by `$high_priority_patch_group` allows reboots to occur.
 # @param [Optional[Boolean]] use_pe_patch
 #   Use the pe_patch module if available (PE 2019.8+). Defaults to true.
 # @param [Optional[Boolean]] classify_pe_patch

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -375,17 +375,34 @@ class patching_as_code(
       default:    {false}
     }
 
-    if $reboot and $enable_patching and !$high_priority_only {
-      # Reboot the node first if a reboot is already pending, except if this is a high prio only run
-      case $facts['kernel'].downcase() {
-        /(windows|linux)/: {
-          reboot_if_pending {'Patching as Code':
-            patch_window => 'Patching as Code - Patch Window',
-            os           => $0
+    # Perform pending reboots pre-patching, except if this is a high prio only run
+    if $enable_patching and !$high_priority_only {
+      if ($reboot and ($updates_to_install.count + $choco_updates_to_install.count > 0)) {
+        # Reboot the node first if a reboot is already pending
+        case $facts['kernel'].downcase() {
+          /(windows|linux)/: {
+            reboot_if_pending {'Patching as Code':
+              patch_window => 'Patching as Code - Patch Window',
+              os           => $0
+            }
+          }
+          default: {
+            fail('Unsupported operating system for Patching as Code!')
           }
         }
-        default: {
-          fail('Unsupported operating system for Patching as Code!')
+      }
+      if ($high_prio_reboot and ($high_prio_updates_to_install.count + $high_prio_choco_updates_to_install.count > 0)) {
+        # Reboot the node first if a reboot is already pending
+        case $facts['kernel'].downcase() {
+          /(windows|linux)/: {
+            reboot_if_pending {'Patching as Code High Priority':
+              patch_window => 'Patching as Code - High Priority Patch Window',
+              os           => $0
+            }
+          }
+          default: {
+            fail('Unsupported operating system for Patching as Code!')
+          }
         }
       }
     }

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -4,19 +4,43 @@
 class patching_as_code::windows::patchday (
   Array $updates,
   Array $choco_updates,
+  Array $high_prio_updates = [],
+  Array $high_prio_choco_updates = []
 ) {
 
-  $updates.each | $kb | {
-    patching_as_code::kb { $kb:
-      ensure      => 'present',
-      maintwindow => 'Patching as Code - Patch Window'
+  if $updates.count > 0 {
+    $updates.each | $kb | {
+      patching_as_code::kb { $kb:
+        ensure      => 'present',
+        maintwindow => 'Patching as Code - Patch Window'
+      }
     }
   }
 
-  $choco_updates.each | $package | {
-    patch_package { $package:
-      patch_window => 'Patching as Code - Patch Window',
-      chocolatey   => true
+  if $high_prio_updates.count > 0 {
+    $updates.each | $kb | {
+      patching_as_code::kb { $kb:
+        ensure      => 'present',
+        maintwindow => 'Patching as Code - High Priority Patch Window'
+      }
+    }
+  }
+
+  if $choco_updates.count > 0 {
+    $choco_updates.each | $package | {
+      patch_package { $package:
+        patch_window => 'Patching as Code - Patch Window',
+        chocolatey   => true
+      }
+    }
+  }
+
+  if $high_prio_choco_updates.count > 0 {
+    $high_prio_choco_updates.each | $package | {
+      patch_package { $package:
+        patch_window => 'Patching as Code - High Priority Patch Window',
+        chocolatey   => true
+      }
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Features**
- Adds support for high priority patches on an alternate patch schedule.
- Adds `high_priority_only` parameter to the `patching_as_code` class, for compatibility with the `puppetlabs/change_window` module.

**Improvements**
- Ensures the last_run fact data only gets written during the patch window.