### PR TITLE
v1.1.2: Fix High Priority patches not getting installed on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 **Bugfixes**
 - Fixes a bug that caused High Priority OS patches for Windows not to be installed, due to the wrong variable being used.
 
+**Improvements**
+- Deduplicates the list of installed patches on the last run, reported in the `patching_as_code` fact.
+
 ## Release 1.1.1
 
 **Improvements**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.1.2
+
+**Bugfixes**
+- Fixes a bug that caused High Priority OS patches for Windows not to be installed, due to the wrong variable being used.
+
 ## Release 1.1.1
 
 **Improvements**

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -451,9 +451,6 @@ class patching_as_code(
               true  => [ Exec["${patch_fact}::exec::fact"], Exec["${patch_fact}::exec::fact_upload"] ],
               false => Exec["${patch_fact}::exec::fact"]
             }
-            notify {'List of high prio patches':
-              message => "${high_prio_updates_to_install}"
-            }
             if ($updates_to_install.count + $choco_updates_to_install.count +
             $high_prio_updates_to_install.count + $high_prio_choco_updates_to_install.count > 0) {
               class { "patching_as_code::${0}::patchday":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -451,6 +451,9 @@ class patching_as_code(
               true  => [ Exec["${patch_fact}::exec::fact"], Exec["${patch_fact}::exec::fact_upload"] ],
               false => Exec["${patch_fact}::exec::fact"]
             }
+            notify {'List of high prio patches':
+              message => "${high_prio_updates_to_install}"
+            }
             if ($updates_to_install.count + $choco_updates_to_install.count +
             $high_prio_updates_to_install.count + $high_prio_choco_updates_to_install.count > 0) {
               class { "patching_as_code::${0}::patchday":
@@ -470,8 +473,8 @@ class patching_as_code(
                 path      => "${facts['puppet_vardir']}/../../patching_as_code/last_run",
                 show_diff => false,
                 content   => Deferred('patching_as_code::last_run',[
-                  $updates_to_install,
-                  $choco_updates_to_install
+                  $updates_to_install.unique,
+                  $choco_updates_to_install.unique
                 ]),
                 schedule  => 'Patching as Code - Patch Window',
                 require   => File["${facts['puppet_vardir']}/../../patching_as_code"],
@@ -489,8 +492,8 @@ class patching_as_code(
                 path      => "${facts['puppet_vardir']}/../../patching_as_code/high_prio_last_run",
                 show_diff => false,
                 content   => Deferred('patching_as_code::high_prio_last_run',[
-                  $high_prio_updates_to_install,
-                  $high_prio_choco_updates_to_install
+                  $high_prio_updates_to_install.unique,
+                  $high_prio_choco_updates_to_install.unique
                 ]),
                 schedule  => 'Patching as Code - High Priority Patch Window',
                 require   => File["${facts['puppet_vardir']}/../../patching_as_code"],

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -17,6 +17,14 @@ class patching_as_code::windows::patchday (
     }
   }
 
+  notify {'List of high prio patches received':
+    message => "${high_prio_updates}"
+  }
+
+  notify {'Count of high prio patches received':
+    message => "${high_prio_updates.count}"
+  }
+
   if $high_prio_updates.count > 0 {
     $updates.each | $kb | {
       patching_as_code::kb { $kb:

--- a/manifests/windows/patchday.pp
+++ b/manifests/windows/patchday.pp
@@ -17,16 +17,8 @@ class patching_as_code::windows::patchday (
     }
   }
 
-  notify {'List of high prio patches received':
-    message => "${high_prio_updates}"
-  }
-
-  notify {'Count of high prio patches received':
-    message => "${high_prio_updates.count}"
-  }
-
   if $high_prio_updates.count > 0 {
-    $updates.each | $kb | {
+    $high_prio_updates.each | $kb | {
       patching_as_code::kb { $kb:
         ensure      => 'present',
         maintwindow => 'Patching as Code - High Priority Patch Window'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Bugfixes**
- Fixes a bug that caused High Priority OS patches for Windows not to be installed, due to the wrong variable being used.

**Improvements**
- Deduplicates the list of installed patches on the last run, reported in the `patching_as_code` fact.