### PR TITLE
Add RHEL9 support to pending_reboot.sh

### DIFF
--- a/lib/patching_as_code/pending_reboot.sh
+++ b/lib/patching_as_code/pending_reboot.sh
@@ -1,7 +1,7 @@
 if [ -f '/usr/bin/needs-restarting' ]
 then
   case $(facter os.release.major) in
-    7|8)
+    7|8|9)
       /usr/bin/needs-restarting -r 2>/dev/null 1>/dev/null
       if [ $? -eq 1 ]
       then

--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
This appears to be all that is required to get RHEL9 support enabled for this module.

It appears to be the root cause of my bug in #63 