### PR TITLE
Release 1.1.5: RHEL 9 reboot detection support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.1.5
+
+**Improvements**
+- Added support for RHEL 9 in the reboot detection script.
+
 ## Release 1.1.4
 
 **Improvements**

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-patching_as_code",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": "puppetlabs",
   "summary": "Automated patching through desired state code",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adds RHEL 9 to the supported operating systems for the reboot detection using `needs-restarting`