### PR TITLE
Exclude 'patching_as_code' fact from running on Darwin systems

### DIFF
--- a/lib/facter/patching_as_code.rb
+++ b/lib/facter/patching_as_code.rb
@@ -1,4 +1,7 @@
 Facter.add('patching_as_code') do
+  confine kernel: 'windows'
+  confine kernel: 'linux'
+  
   setcode do
     directory      = "#{Facter.value(:puppet_vardir)}/../../patching_as_code"
     file           = "#{directory}/last_run"


### PR DESCRIPTION
Previously, the 'patching_as_code' fact was executing on all operating systems, including Darwin (macOS) systems. However, the fact is not applicable to Darwin systems, and executing it on those platforms can cause unnecessary overhead.

This commit modifies the fact code by adding the necessary conditions to exclude the 'patching_as_code' fact from running on Darwin systems. The fact will now only execute on Windows and Linux systems, improving efficiency and avoiding any potential issues on unsupported platforms.

By excluding the 'patching_as_code' fact from running on Darwin systems, we ensure that the fact execution is limited to the relevant operating systems, aligning with the intended behavior of the code.